### PR TITLE
Add os/apps directory and tsconfig paths

### DIFF
--- a/core/encoding/tsconfig.json
+++ b/core/encoding/tsconfig.json
@@ -16,7 +16,8 @@
       "@primeos/core-precision": ["core/precision/index.ts"],
       "@primeos/core-precision/*": ["core/precision/*"],
       "@primeos/os-model": ["os/model/index.ts"],
-      "@primeos/os-logging": ["os/logging/index.ts"]
+      "@primeos/os-logging": ["os/logging/index.ts"],
+      "@primeos/os-apps": ["os/apps/index.ts"]
     },
     "types": ["node", "jest"]
   },

--- a/core/jest.config.js
+++ b/core/jest.config.js
@@ -24,7 +24,8 @@ module.exports = {
     '^@primeos/core/(.*)$': '<rootDir>/$1',
     '^@primeos/os-model$': '<rootDir>/../os/model',
     '^@primeos/os-logging$': '<rootDir>/../os/logging',
-    '^@primeos/os-tests$': '<rootDir>/../os/os-tests'
+    '^@primeos/os-tests$': '<rootDir>/../os/os-tests',
+    '^@primeos/os-apps$': '<rootDir>/../os/apps'
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testTimeout: 30000,

--- a/core/precision/tsconfig.json
+++ b/core/precision/tsconfig.json
@@ -25,7 +25,8 @@
       "@primeos/core/precision/*": ["./core/precision/*"],
       "@primeos/os-model": ["./os/model/index.ts"],
       "@primeos/os-logging": ["./os/logging/index.ts"],
-      "@primeos/os-tests": ["./os/os-tests/index.ts"]
+      "@primeos/os-tests": ["./os/os-tests/index.ts"],
+      "@primeos/os-apps": ["./os/apps/index.ts"]
     }
   },
   "include": [

--- a/core/prime/tsconfig.json
+++ b/core/prime/tsconfig.json
@@ -24,7 +24,8 @@
       "@primeos/core-precision": ["core/precision/index.ts"],
       "@primeos/core-precision/*": ["core/precision/*"],
       "@primeos/os-model": ["os/model/index.ts"],
-      "@primeos/os-logging": ["os/logging/index.ts"]
+      "@primeos/os-logging": ["os/logging/index.ts"],
+      "@primeos/os-apps": ["os/apps/index.ts"]
     }
   },
   "include": [

--- a/core/stream/tsconfig.json
+++ b/core/stream/tsconfig.json
@@ -24,7 +24,8 @@
       "@primeos/core-encoding": ["core/encoding/index.ts"],
       "@primeos/core-integrity": ["core/integrity/index.ts"],
       "@primeos/os-model": ["os/model/index.ts"],
-      "@primeos/os-logging": ["os/logging/index.ts"]
+      "@primeos/os-logging": ["os/logging/index.ts"],
+      "@primeos/os-apps": ["os/apps/index.ts"]
     }
   },
   "include": [

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -36,7 +36,8 @@
       "@primeos/core/*": ["./*"],
       "@primeos/os-model": ["../os/model"],
       "@primeos/os-logging": ["../os/logging"],
-      "@primeos/os-tests": ["../os/os-tests"]
+      "@primeos/os-tests": ["../os/os-tests"],
+      "@primeos/os-apps": ["../os/apps"]
     }
   },
   "include": [

--- a/os/apps/README.md
+++ b/os/apps/README.md
@@ -1,0 +1,5 @@
+# PrimeOS Application Modules
+
+This directory contains top-level application modules built on top of the PrimeOS operating system layer. Applications leverage the OS capabilities such as the model system and logging framework to provide domain-specific functionality.
+
+Each application should follow the standard PrimeOS module pattern and include its own documentation, tests and build configuration.

--- a/os/apps/index.ts
+++ b/os/apps/index.ts
@@ -1,0 +1,9 @@
+/**
+ * PrimeOS Application Modules
+ * ===========================
+ *
+ * Placeholder entry point for application modules. Individual applications
+ * should export their functionality from subdirectories within this folder.
+ */
+
+export {};


### PR DESCRIPTION
## Summary
- create `os/apps` with placeholder exports and documentation
- map `@primeos/os-apps` in TS configs and Jest config

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684574dd318483208c104be74c7ded2a