### PR TITLE
Add Hanoi tower solver module

### DIFF
--- a/os/apps/hanoi/README.md
+++ b/os/apps/hanoi/README.md
@@ -1,0 +1,141 @@
+# hanoi
+
+Tower of Hanoi solver
+
+## Overview
+
+This module follows the standard PrimeOS module pattern, implementing the PrimeOS Model interface for consistent lifecycle management, state tracking, error handling, and integrated logging.
+
+## Features
+
+- Fully integrates with the PrimeOS model system
+- Built-in logging capabilities
+- Standard lifecycle management (initialize, process, reset, terminate)
+- Automatic error handling and result formatting
+- Deterministic recursive solver for any starting configuration
+
+## Installation
+
+```bash
+npm install hanoi
+```
+
+## Usage
+
+```typescript
+import { createAndInitializeHanoi } from 'hanoi';
+
+// Create and initialize with 3 disks
+const hanoi = await createAndInitializeHanoi({ disks: 3 });
+
+// Automatically solve the puzzle
+await hanoi.solve();
+
+console.log(hanoi.getState().towers);
+
+await hanoi.terminate();
+```
+
+## API
+
+### `createHanoi(options)`
+
+Creates a new hanoi instance with the specified options.
+
+Parameters:
+- `options` - Optional configuration options
+
+Returns:
+- A hanoi instance implementing HanoiInterface
+
+### HanoiInterface
+
+The main interface implemented by hanoi. Extends the ModelInterface.
+
+Methods:
+- `initialize()` - Initialize the module (required before processing)
+- `process<T, R>(input: T)` - Process the input data and return a result
+- `reset()` - Reset the module to its initial state
+- `terminate()` - Release resources and shut down the module
+- `getState()` - Get the current module state
+- `getLogger()` - Get the module's logger instance
+
+### Options
+
+Configuration options for hanoi:
+
+```typescript
+interface HanoiOptions {
+  // Enable debug mode
+  debug?: boolean;
+  
+  // Module name
+  name?: string;
+  
+  // Module version
+  version?: string;
+
+  // Number of disks
+  disks?: number;
+
+  // Custom starting towers
+  towers?: number[][];
+}
+```
+
+### Result Format
+
+All operations return a standardized result format:
+
+```typescript
+{
+  success: true,          // Success indicator
+  data: { ... },          // Operation result data
+  timestamp: 1620000000,  // Operation timestamp
+  source: 'module-name'   // Source module
+}
+```
+
+## Lifecycle Management
+
+The module follows a defined lifecycle:
+
+1. **Uninitialized**: Initial state when created
+2. **Initializing**: During setup and resource allocation
+3. **Ready**: Available for processing
+4. **Processing**: Actively handling an operation
+5. **Error**: Encountered an issue
+6. **Terminating**: During resource cleanup
+7. **Terminated**: Final state after cleanup
+
+Always follow this sequence:
+1. Create the module with `createAndInitializeHanoi`
+2. Call `solve()` or process moves
+3. Clean up with `terminate()`
+
+## Custom Implementation
+
+You can extend the functionality by adding module-specific methods to the implementation.
+
+## CLI Usage
+
+A command line entry is available at `src/cli.ts`:
+
+```bash
+npx ts-node src/cli.ts --disks=4 --auto
+```
+
+Use `--no-auto` to just display the initial state without solving.
+
+## Error Handling
+
+Errors are automatically caught and returned in a standardized format:
+
+```typescript
+{
+  success: false,
+  error: "Error message",
+  timestamp: 1620000000,
+  source: "module-name"
+}
+```

--- a/os/apps/hanoi/index.ts
+++ b/os/apps/hanoi/index.ts
@@ -1,0 +1,165 @@
+/**
+ * hanoi Implementation
+ * =====
+ * 
+ * This module implements Tower of Hanoi solver.
+ * It follows the standard PrimeOS model pattern.
+ */
+
+import {
+  BaseModel,
+  ModelResult
+} from '../os/model';
+import {
+  HanoiOptions,
+  HanoiInterface,
+  HanoiState,
+  HanoiResult
+} from './types';
+
+/**
+ * Default options for hanoi
+ */
+const DEFAULT_OPTIONS: HanoiOptions = {
+  debug: false,
+  name: 'hanoi',
+  version: '0.1.0',
+  disks: 3
+};
+
+/**
+ * Main implementation of hanoi
+ */
+export class HanoiImplementation extends BaseModel implements HanoiInterface {
+  protected state: HanoiState;
+
+  constructor(options: HanoiOptions = {}) {
+    super({ ...DEFAULT_OPTIONS, ...options });
+    this.state = {
+      ...super.getState(),
+      towers: [[], [], []],
+      moves: []
+    } as HanoiState;
+  }
+  
+  /**
+   * Module-specific initialization logic
+   */
+  protected async onInitialize(): Promise<void> {
+    const disks = this.options.disks || DEFAULT_OPTIONS.disks!;
+    if (this.options.towers) {
+      this.state.towers = this.options.towers.map(t => [...t]);
+    } else {
+      this.state.towers = [
+        Array.from({ length: disks }, (_, i) => disks - i),
+        [],
+        []
+      ];
+    }
+    this.state.moves = [];
+
+    await this.logger.debug('Hanoi initialized with options', this.options);
+  }
+  
+  /**
+   * Process input data with module-specific logic
+   */
+  protected async onProcess<T = unknown, R = unknown>(input: T): Promise<R> {
+    const command: any = input || { action: 'solve' };
+
+    if (command.action === 'move') {
+      const res = this.moveDisk(command.from, command.to);
+      return { towers: this.state.towers } as unknown as R;
+    }
+
+    await this.solve();
+    return { towers: this.state.towers, moves: this.state.moves } as unknown as R;
+  }
+
+  moveDisk(from: number, to: number): HanoiResult {
+    const source = this.state.towers[from];
+    const dest = this.state.towers[to];
+    if (!source || !dest) {
+      return this.createResult(false, undefined, 'Invalid tower index');
+    }
+    if (source.length === 0) {
+      return this.createResult(false, undefined, 'No disk to move');
+    }
+    const disk = source[source.length - 1];
+    if (dest.length > 0 && dest[dest.length - 1] < disk) {
+      return this.createResult(false, undefined, 'Cannot place larger disk on smaller disk');
+    }
+    source.pop();
+    dest.push(disk);
+    this.state.moves.push({ from, to, disk });
+    return this.createResult(true, { from, to, disk });
+  }
+
+  async solve(): Promise<HanoiResult<number[][]>> {
+    const maxDisk = Math.max(0, ...this.state.towers.flat());
+    await this.solveRecursive(maxDisk, this.findDisk(maxDisk), 2, this.getAuxTower(this.findDisk(maxDisk), 2));
+    return this.createResult(true, this.state.towers.map(t => [...t]));
+  }
+
+  private async solveRecursive(n: number, from: number, to: number, aux: number): Promise<void> {
+    if (n <= 0) return;
+    const currentPos = this.findDisk(n);
+    if (currentPos !== from) {
+      from = currentPos;
+      aux = this.getAuxTower(from, to);
+    }
+    await this.solveRecursive(n - 1, from, aux, to);
+    this.moveDisk(this.findDisk(n), to);
+    await this.solveRecursive(n - 1, aux, to, from);
+  }
+
+  private findDisk(n: number): number {
+    for (let i = 0; i < 3; i++) {
+      if (this.state.towers[i].includes(n)) return i;
+    }
+    throw new Error(`Disk ${n} not found`);
+  }
+
+  private getAuxTower(from: number, to: number): number {
+    return [0, 1, 2].find(i => i !== from && i !== to)!;
+  }
+  
+  /**
+   * Clean up resources when module is reset
+   */
+  protected async onReset(): Promise<void> {
+    await this.onInitialize();
+  }
+  
+  /**
+   * Clean up resources when module is terminated
+   */
+  protected async onTerminate(): Promise<void> {
+    // Release any module-specific resources
+    await this.logger.debug('Terminating Hanoi');
+  }
+}
+
+/**
+ * Create a hanoi instance with the specified options
+ */
+export function createHanoi(options: HanoiOptions = {}): HanoiInterface {
+  return new HanoiImplementation(options);
+}
+
+/**
+ * Create and initialize a hanoi instance in a single step
+ */
+export async function createAndInitializeHanoi(options: HanoiOptions = {}): Promise<HanoiInterface> {
+  const instance = createHanoi(options);
+  const result = await instance.initialize();
+  
+  if (!result.success) {
+    throw new Error(`Failed to initialize hanoi: ${result.error}`);
+  }
+  
+  return instance;
+}
+
+// Export types
+export * from './types';

--- a/os/apps/hanoi/package.json
+++ b/os/apps/hanoi/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "hanoi",
+  "version": "0.1.0",
+  "description": "Tower of Hanoi solver",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write \"**/*.ts\""
+  },
+  "keywords": [
+    "primeos",
+    "hanoi"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "os": "^0.1.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.3",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.1.6"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
+  }
+}

--- a/os/apps/hanoi/test.ts
+++ b/os/apps/hanoi/test.ts
@@ -1,0 +1,30 @@
+import { createAndInitializeHanoi, HanoiInterface } from './index';
+
+function isSolved(state: HanoiInterface['getState']) {
+  const towers = (typeof state === 'function' ? state() : state).towers;
+  const n = Math.max(...towers.flat(), 0);
+  return (
+    towers[0].length === 0 &&
+    towers[1].length === 0 &&
+    towers[2].join(',') === Array.from({ length: n }, (_, i) => n - i).join(',')
+  );
+}
+
+describe('hanoi solver', () => {
+  test('solves default configuration', async () => {
+    const h: HanoiInterface = await createAndInitializeHanoi({ disks: 3 });
+    await h.solve();
+    expect(isSolved(() => h.getState())).toBe(true);
+    expect(h.getState().moves.length).toBe(7);
+    await h.terminate();
+  });
+
+  test('solves custom starting state', async () => {
+    const towers = [[], [3, 2, 1], []];
+    const h: HanoiInterface = await createAndInitializeHanoi({ disks: 3, towers });
+    await h.solve();
+    expect(isSolved(() => h.getState())).toBe(true);
+    await h.terminate();
+  });
+});
+

--- a/os/apps/hanoi/types.ts
+++ b/os/apps/hanoi/types.ts
@@ -1,0 +1,71 @@
+/**
+ * hanoi Types
+ * =====
+ * 
+ * Type definitions for the hanoi module.
+ */
+
+import {
+  ModelOptions,
+  ModelInterface,
+  ModelResult,
+  ModelState
+} from '../os/model/types';
+import { LoggingInterface } from '../os/logging';
+
+/**
+ * Configuration options for hanoi
+ */
+export interface HanoiOptions extends ModelOptions {
+  /**
+   * Number of disks in the puzzle
+   */
+  disks?: number;
+
+  /**
+   * Optional starting tower configuration. Each tower is an array of disk sizes
+   * with the smallest disk represented by 1 and the largest by `disks`.
+   * The bottom of the tower is the first element in the array.
+   */
+  towers?: number[][];
+}
+
+/**
+ * Core interface for hanoi functionality
+ */
+export interface HanoiInterface extends ModelInterface {
+  /**
+   * Execute one disk move from one tower to another
+   */
+  moveDisk(from: number, to: number): HanoiResult;
+
+  /**
+   * Automatically solve the puzzle from the current state
+   */
+  solve(): Promise<HanoiResult<number[][]>>;
+
+  /**
+   * Access the module logger
+   */
+  getLogger(): LoggingInterface;
+}
+
+/**
+ * Result of hanoi operations
+ */
+export type HanoiResult<T = unknown> = ModelResult<T>;
+
+/**
+ * Extended state for hanoi module
+ */
+export interface HanoiState extends ModelState {
+  /**
+   * Current tower configuration
+   */
+  towers: number[][];
+
+  /**
+   * History of moves performed
+   */
+  moves: Array<{ from: number; to: number; disk: number }>;
+}

--- a/os/apps/index.ts
+++ b/os/apps/index.ts
@@ -6,4 +6,5 @@
  * should export their functionality from subdirectories within this folder.
  */
 
-export {};
+export * from './hanoi';
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { createAndInitializeHanoi } from '../os/apps/hanoi';
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts: { disks?: number; auto: boolean } = { auto: false };
+  for (const a of args) {
+    if (a.startsWith('--disks=')) {
+      opts.disks = parseInt(a.split('=')[1], 10);
+    } else if (a === '--auto') {
+      opts.auto = true;
+    } else if (a === '--no-auto') {
+      opts.auto = false;
+    }
+  }
+  return opts;
+}
+
+async function main() {
+  const opts = parseArgs();
+  const hanoi = await createAndInitializeHanoi({ disks: opts.disks });
+
+  if (opts.auto) {
+    await hanoi.solve();
+  }
+
+  console.log(JSON.stringify(hanoi.getState().towers));
+  console.log(`Moves: ${hanoi.getState().moves.length}`);
+  await hanoi.terminate();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- generate `hanoi` module under `os/apps`
- implement deterministic Tower of Hanoi solver
- expose CLI entry `src/cli.ts`
- export application from apps index
- document module usage and CLI
- add unit tests for solver logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684575b5e7f88320bd48bbc58c955b43