### PR TITLE
Implement TestableInterface tests for Hanoi

### DIFF
--- a/os/apps/hanoi/hanoi.jest.test.ts
+++ b/os/apps/hanoi/hanoi.jest.test.ts
@@ -1,0 +1,30 @@
+import { createAndInitializeHanoi, HanoiInterface } from './index';
+
+function isSolved(state: HanoiInterface['getState']) {
+  const towers = (typeof state === 'function' ? state() : state).towers;
+  const n = Math.max(...towers.flat(), 0);
+  return (
+    towers[0].length === 0 &&
+    towers[1].length === 0 &&
+    towers[2].join(',') === Array.from({ length: n }, (_, i) => n - i).join(',')
+  );
+}
+
+describe('hanoi solver', () => {
+  test('solves default configuration', async () => {
+    const h: HanoiInterface = await createAndInitializeHanoi({ disks: 3 });
+    await h.solve();
+    expect(isSolved(() => h.getState())).toBe(true);
+    expect(h.getState().moves.length).toBe(7);
+    await h.terminate();
+  });
+
+  test('solves custom starting state', async () => {
+    const towers = [[], [3, 2, 1], []];
+    const h: HanoiInterface = await createAndInitializeHanoi({ disks: 3, towers });
+    await h.solve();
+    expect(isSolved(() => h.getState())).toBe(true);
+    await h.terminate();
+  });
+});
+

--- a/os/apps/hanoi/index.ts
+++ b/os/apps/hanoi/index.ts
@@ -163,3 +163,7 @@ export async function createAndInitializeHanoi(options: HanoiOptions = {}): Prom
 
 // Export types
 export * from './types';
+
+// Export TestableInterface implementation for the testing framework
+export { default as HanoiTests } from './test';
+export { default } from './test';


### PR DESCRIPTION
## Summary
- add TestableInterface-based tests for the Hanoi module
- expose `HanoiTests` from the Hanoi index
- preserve original jest tests under a new name

## Testing
- `npm run test:all` *(fails: ts-node not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68457a81e16483209607578c0d5fd487