### PR TITLE
Add Chess modules skeletons

### DIFF
--- a/core/chess-core/README.md
+++ b/core/chess-core/README.md
@@ -1,0 +1,135 @@
+# chess-core
+
+ChessCore implementation for PrimeOS
+
+## Overview
+
+This module follows the standard PrimeOS module pattern, implementing the PrimeOS Model interface for consistent lifecycle management, state tracking, error handling, and integrated logging.
+
+## Features
+
+- Fully integrates with the PrimeOS model system
+- Built-in logging capabilities
+- Standard lifecycle management (initialize, process, reset, terminate)
+- Automatic error handling and result formatting
+
+## Installation
+
+```bash
+npm install chess-core
+```
+
+## Usage
+
+```typescript
+import { createChessCore } from 'chess-core';
+
+// Create an instance
+const instance = createChessCore({
+  debug: true,
+  name: 'chess-core-instance',
+  version: '1.0.0'
+});
+
+// Initialize the module
+await instance.initialize();
+
+// Process data
+const result = await instance.process('example-input');
+console.log(result);
+
+// Clean up when done
+await instance.terminate();
+```
+
+## API
+
+### `createChessCore(options)`
+
+Creates a new chess-core instance with the specified options.
+
+Parameters:
+- `options` - Optional configuration options
+
+Returns:
+- A chess-core instance implementing ChessCoreInterface
+
+### ChessCoreInterface
+
+The main interface implemented by chess-core. Extends the ModelInterface.
+
+Methods:
+- `initialize()` - Initialize the module (required before processing)
+- `process<T, R>(input: T)` - Process the input data and return a result
+- `reset()` - Reset the module to its initial state
+- `terminate()` - Release resources and shut down the module
+- `getState()` - Get the current module state
+- `getLogger()` - Get the module's logger instance
+
+### Options
+
+Configuration options for chess-core:
+
+```typescript
+interface ChessCoreOptions {
+  // Enable debug mode
+  debug?: boolean;
+  
+  // Module name
+  name?: string;
+  
+  // Module version
+  version?: string;
+  
+  // Module-specific options
+  // ...
+}
+```
+
+### Result Format
+
+All operations return a standardized result format:
+
+```typescript
+{
+  success: true,          // Success indicator
+  data: { ... },          // Operation result data
+  timestamp: 1620000000,  // Operation timestamp
+  source: 'module-name'   // Source module
+}
+```
+
+## Lifecycle Management
+
+The module follows a defined lifecycle:
+
+1. **Uninitialized**: Initial state when created
+2. **Initializing**: During setup and resource allocation
+3. **Ready**: Available for processing
+4. **Processing**: Actively handling an operation
+5. **Error**: Encountered an issue
+6. **Terminating**: During resource cleanup
+7. **Terminated**: Final state after cleanup
+
+Always follow this sequence:
+1. Create the module with `createChessCore`
+2. Initialize with `initialize()`
+3. Process data with `process()`
+4. Clean up with `terminate()`
+
+## Custom Implementation
+
+You can extend the functionality by adding module-specific methods to the implementation.
+
+## Error Handling
+
+Errors are automatically caught and returned in a standardized format:
+
+```typescript
+{
+  success: false,
+  error: "Error message",
+  timestamp: 1620000000,
+  source: "module-name"
+}
+```

--- a/core/chess-core/index.ts
+++ b/core/chess-core/index.ts
@@ -1,0 +1,111 @@
+/**
+ * chess-core Implementation
+ * ==========
+ * 
+ * This module implements ChessCore implementation for PrimeOS.
+ * It follows the standard PrimeOS model pattern.
+ */
+
+import {
+  BaseModel,
+  ModelResult,
+  ModelLifecycleState,
+  createAndInitializeModel
+} from '../os/model';
+import {
+  ChessCoreOptions,
+  ChessCoreInterface,
+  ChessCoreState
+} from './types';
+
+/**
+ * Default options for chess-core
+ */
+const DEFAULT_OPTIONS: ChessCoreOptions = {
+  debug: false,
+  name: 'chess-core',
+  version: '0.1.0'
+};
+
+/**
+ * Main implementation of chess-core
+ */
+export class ChessCoreImplementation extends BaseModel implements ChessCoreInterface {
+  /**
+   * Create a new chess-core instance
+   */
+  constructor(options: ChessCoreOptions = {}) {
+    // Initialize BaseModel with options
+    super({ ...DEFAULT_OPTIONS, ...options });
+    
+    // Add any custom initialization here
+  }
+  
+  /**
+   * Module-specific initialization logic
+   */
+  protected async onInitialize(): Promise<void> {
+    // Custom initialization logic goes here
+    
+    // Add custom state if needed
+    this.state.custom = {
+      // Add module-specific state properties here
+    };
+    
+    // Log initialization
+    await this.logger.debug('ChessCore initialized with options', this.options);
+  }
+  
+  /**
+   * Process input data with module-specific logic
+   */
+  protected async onProcess<T = unknown, R = unknown>(input: T): Promise<R> {
+    await this.logger.debug('Processing input in ChessCore', input);
+    
+    // TODO: Implement actual processing logic here
+    // This is just a placeholder - replace with real implementation
+    const result = input as unknown as R;
+    
+    return result;
+  }
+  
+  /**
+   * Clean up resources when module is reset
+   */
+  protected async onReset(): Promise<void> {
+    // Clean up any module-specific resources
+    await this.logger.debug('Resetting ChessCore');
+  }
+  
+  /**
+   * Clean up resources when module is terminated
+   */
+  protected async onTerminate(): Promise<void> {
+    // Release any module-specific resources
+    await this.logger.debug('Terminating ChessCore');
+  }
+}
+
+/**
+ * Create a chess-core instance with the specified options
+ */
+export function createChessCore(options: ChessCoreOptions = {}): ChessCoreInterface {
+  return new ChessCoreImplementation(options);
+}
+
+/**
+ * Create and initialize a chess-core instance in a single step
+ */
+export async function createAndInitializeChessCore(options: ChessCoreOptions = {}): Promise<ChessCoreInterface> {
+  const instance = createChessCore(options);
+  const result = await instance.initialize();
+  
+  if (!result.success) {
+    throw new Error(`Failed to initialize chess-core: ${result.error}`);
+  }
+  
+  return instance;
+}
+
+// Export types
+export * from './types';

--- a/core/chess-core/package.json
+++ b/core/chess-core/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "chess-core",
+  "version": "0.1.0",
+  "description": "ChessCore implementation for PrimeOS",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write \"**/*.ts\""
+  },
+  "keywords": [
+    "primeos",
+    "chess-core"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "primeos": "^0.1.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.3",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.1.6"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
+  }
+}

--- a/core/chess-core/test.ts
+++ b/core/chess-core/test.ts
@@ -1,0 +1,138 @@
+/**
+ * chess-core Tests
+ * ==========
+ * 
+ * Test suite for the chess-core module.
+ */
+
+import { 
+  createChessCore,
+  ChessCoreInterface,
+  ChessCoreOptions,
+  ChessCoreState
+} from './index';
+import { ModelLifecycleState } from '../os/model';
+
+describe('chess-core', () => {
+  let instance: ChessCoreInterface;
+  
+  beforeEach(async () => {
+    // Create a fresh instance before each test
+    instance = createChessCore({
+      debug: true,
+      name: 'test-chess-core'
+    });
+    
+    // Initialize the instance
+    await instance.initialize();
+  });
+  
+  afterEach(async () => {
+    // Clean up after each test
+    await instance.terminate();
+  });
+  
+  describe('Lifecycle Management', () => {
+    test('should initialize correctly', () => {
+      const state = instance.getState();
+      expect(state.lifecycle).toBe(ModelLifecycleState.Ready);
+    });
+    
+    test('should reset state', async () => {
+      // Perform some operations
+      await instance.process('test-data');
+      
+      // Reset the instance
+      const result = await instance.reset();
+      expect(result.success).toBe(true);
+      
+      // Check state after reset
+      const state = instance.getState();
+      expect(state.operationCount.total).toBe(0);
+    });
+    
+    test('should terminate properly', async () => {
+      const result = await instance.terminate();
+      expect(result.success).toBe(true);
+      
+      const state = instance.getState();
+      expect(state.lifecycle).toBe(ModelLifecycleState.Terminated);
+    });
+  });
+  
+  describe('Basic functionality', () => {
+    test('should process input data', async () => {
+      const testInput = 'test-data';
+      const result = await instance.process(testInput);
+      
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.timestamp).toBeDefined();
+    });
+    
+    test('should access logger', () => {
+      const logger = instance.getLogger();
+      expect(logger).toBeDefined();
+      expect(typeof logger.info).toBe('function');
+    });
+    
+    test('should handle custom state', async () => {
+      const state = instance.getState();
+      expect(state.custom).toBeDefined();
+      
+      // Add assertions specific to module's custom state
+    });
+  });
+  
+  describe('Configuration options', () => {
+    test('should use default options when none provided', async () => {
+      const defaultInstance = createChessCore();
+      await defaultInstance.initialize();
+      
+      expect(defaultInstance).toBeDefined();
+      
+      await defaultInstance.terminate();
+    });
+    
+    test('should respect custom options', async () => {
+      const customOptions: ChessCoreOptions = {
+        debug: true,
+        name: 'custom-chess-core',
+        version: '1.2.3',
+        // Add more custom options as needed
+      };
+      
+      const customInstance = createChessCore(customOptions);
+      await customInstance.initialize();
+      
+      // Process something to get a result with source
+      const result = await customInstance.process('test');
+      expect(result.source).toContain('custom-chess-core');
+      expect(result.source).toContain('1.2.3');
+      
+      await customInstance.terminate();
+    });
+  });
+  
+  describe('Error handling', () => {
+    test('should handle processing errors gracefully', async () => {
+      // Create a bad input that will cause an error
+      // This is just a placeholder - you may need to adjust for your specific module
+      const badInput = undefined;
+      
+      // Process should not throw but return error result
+      const result = await instance.process(badInput as any);
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+  
+  // Template placeholder: Add more test suites specific to the module
+  describe('Module-specific functionality', () => {
+    test('should implement module-specific features', () => {
+      // This is a placeholder for module-specific tests
+      // Replace with actual tests for the module's features
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/core/chess-core/types.ts
+++ b/core/chess-core/types.ts
@@ -1,0 +1,55 @@
+/**
+ * chess-core Types
+ * ==========
+ * 
+ * Type definitions for the chess-core module.
+ */
+
+import {
+  ModelOptions,
+  ModelInterface,
+  ModelResult,
+  ModelState,
+  ModelLifecycleState
+} from '../os/model/types';
+import { LoggingInterface } from '../os/logging';
+
+/**
+ * Configuration options for chess-core
+ */
+export interface ChessCoreOptions extends ModelOptions {
+  /**
+   * Module-specific options go here
+   */
+  // Add module-specific options here
+}
+
+/**
+ * Core interface for chess-core functionality
+ */
+export interface ChessCoreInterface extends ModelInterface {
+  /**
+   * Module-specific methods go here
+   */
+  // Add module-specific methods here
+  
+  /**
+   * Access the module logger
+   */
+  getLogger(): LoggingInterface;
+}
+
+/**
+ * Result of chess-core operations
+ */
+export type ChessCoreResult<T = unknown> = ModelResult<T>;
+
+/**
+ * Extended state for chess-core module
+ */
+export interface ChessCoreState extends ModelState {
+  /**
+   * Module-specific state properties go here
+   */
+  // Add module-specific state properties here
+}

--- a/kernel/chess-engine/README.md
+++ b/kernel/chess-engine/README.md
@@ -1,0 +1,135 @@
+# chess-engine
+
+ChessEngine implementation for PrimeOS
+
+## Overview
+
+This module follows the standard PrimeOS module pattern, implementing the PrimeOS Model interface for consistent lifecycle management, state tracking, error handling, and integrated logging.
+
+## Features
+
+- Fully integrates with the PrimeOS model system
+- Built-in logging capabilities
+- Standard lifecycle management (initialize, process, reset, terminate)
+- Automatic error handling and result formatting
+
+## Installation
+
+```bash
+npm install chess-engine
+```
+
+## Usage
+
+```typescript
+import { createChessEngine } from 'chess-engine';
+
+// Create an instance
+const instance = createChessEngine({
+  debug: true,
+  name: 'chess-engine-instance',
+  version: '1.0.0'
+});
+
+// Initialize the module
+await instance.initialize();
+
+// Process data
+const result = await instance.process('example-input');
+console.log(result);
+
+// Clean up when done
+await instance.terminate();
+```
+
+## API
+
+### `createChessEngine(options)`
+
+Creates a new chess-engine instance with the specified options.
+
+Parameters:
+- `options` - Optional configuration options
+
+Returns:
+- A chess-engine instance implementing ChessEngineInterface
+
+### ChessEngineInterface
+
+The main interface implemented by chess-engine. Extends the ModelInterface.
+
+Methods:
+- `initialize()` - Initialize the module (required before processing)
+- `process<T, R>(input: T)` - Process the input data and return a result
+- `reset()` - Reset the module to its initial state
+- `terminate()` - Release resources and shut down the module
+- `getState()` - Get the current module state
+- `getLogger()` - Get the module's logger instance
+
+### Options
+
+Configuration options for chess-engine:
+
+```typescript
+interface ChessEngineOptions {
+  // Enable debug mode
+  debug?: boolean;
+  
+  // Module name
+  name?: string;
+  
+  // Module version
+  version?: string;
+  
+  // Module-specific options
+  // ...
+}
+```
+
+### Result Format
+
+All operations return a standardized result format:
+
+```typescript
+{
+  success: true,          // Success indicator
+  data: { ... },          // Operation result data
+  timestamp: 1620000000,  // Operation timestamp
+  source: 'module-name'   // Source module
+}
+```
+
+## Lifecycle Management
+
+The module follows a defined lifecycle:
+
+1. **Uninitialized**: Initial state when created
+2. **Initializing**: During setup and resource allocation
+3. **Ready**: Available for processing
+4. **Processing**: Actively handling an operation
+5. **Error**: Encountered an issue
+6. **Terminating**: During resource cleanup
+7. **Terminated**: Final state after cleanup
+
+Always follow this sequence:
+1. Create the module with `createChessEngine`
+2. Initialize with `initialize()`
+3. Process data with `process()`
+4. Clean up with `terminate()`
+
+## Custom Implementation
+
+You can extend the functionality by adding module-specific methods to the implementation.
+
+## Error Handling
+
+Errors are automatically caught and returned in a standardized format:
+
+```typescript
+{
+  success: false,
+  error: "Error message",
+  timestamp: 1620000000,
+  source: "module-name"
+}
+```

--- a/kernel/chess-engine/index.ts
+++ b/kernel/chess-engine/index.ts
@@ -1,0 +1,111 @@
+/**
+ * chess-engine Implementation
+ * ============
+ * 
+ * This module implements ChessEngine implementation for PrimeOS.
+ * It follows the standard PrimeOS model pattern.
+ */
+
+import {
+  BaseModel,
+  ModelResult,
+  ModelLifecycleState,
+  createAndInitializeModel
+} from '../os/model';
+import {
+  ChessEngineOptions,
+  ChessEngineInterface,
+  ChessEngineState
+} from './types';
+
+/**
+ * Default options for chess-engine
+ */
+const DEFAULT_OPTIONS: ChessEngineOptions = {
+  debug: false,
+  name: 'chess-engine',
+  version: '0.1.0'
+};
+
+/**
+ * Main implementation of chess-engine
+ */
+export class ChessEngineImplementation extends BaseModel implements ChessEngineInterface {
+  /**
+   * Create a new chess-engine instance
+   */
+  constructor(options: ChessEngineOptions = {}) {
+    // Initialize BaseModel with options
+    super({ ...DEFAULT_OPTIONS, ...options });
+    
+    // Add any custom initialization here
+  }
+  
+  /**
+   * Module-specific initialization logic
+   */
+  protected async onInitialize(): Promise<void> {
+    // Custom initialization logic goes here
+    
+    // Add custom state if needed
+    this.state.custom = {
+      // Add module-specific state properties here
+    };
+    
+    // Log initialization
+    await this.logger.debug('ChessEngine initialized with options', this.options);
+  }
+  
+  /**
+   * Process input data with module-specific logic
+   */
+  protected async onProcess<T = unknown, R = unknown>(input: T): Promise<R> {
+    await this.logger.debug('Processing input in ChessEngine', input);
+    
+    // TODO: Implement actual processing logic here
+    // This is just a placeholder - replace with real implementation
+    const result = input as unknown as R;
+    
+    return result;
+  }
+  
+  /**
+   * Clean up resources when module is reset
+   */
+  protected async onReset(): Promise<void> {
+    // Clean up any module-specific resources
+    await this.logger.debug('Resetting ChessEngine');
+  }
+  
+  /**
+   * Clean up resources when module is terminated
+   */
+  protected async onTerminate(): Promise<void> {
+    // Release any module-specific resources
+    await this.logger.debug('Terminating ChessEngine');
+  }
+}
+
+/**
+ * Create a chess-engine instance with the specified options
+ */
+export function createChessEngine(options: ChessEngineOptions = {}): ChessEngineInterface {
+  return new ChessEngineImplementation(options);
+}
+
+/**
+ * Create and initialize a chess-engine instance in a single step
+ */
+export async function createAndInitializeChessEngine(options: ChessEngineOptions = {}): Promise<ChessEngineInterface> {
+  const instance = createChessEngine(options);
+  const result = await instance.initialize();
+  
+  if (!result.success) {
+    throw new Error(`Failed to initialize chess-engine: ${result.error}`);
+  }
+  
+  return instance;
+}
+
+// Export types
+export * from './types';

--- a/kernel/chess-engine/package.json
+++ b/kernel/chess-engine/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "chess-engine",
+  "version": "0.1.0",
+  "description": "ChessEngine implementation for PrimeOS",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write \"**/*.ts\""
+  },
+  "keywords": [
+    "primeos",
+    "chess-engine"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "primeos": "^0.1.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.3",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.1.6"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
+  }
+}

--- a/kernel/chess-engine/test.ts
+++ b/kernel/chess-engine/test.ts
@@ -1,0 +1,138 @@
+/**
+ * chess-engine Tests
+ * ============
+ * 
+ * Test suite for the chess-engine module.
+ */
+
+import { 
+  createChessEngine,
+  ChessEngineInterface,
+  ChessEngineOptions,
+  ChessEngineState
+} from './index';
+import { ModelLifecycleState } from '../os/model';
+
+describe('chess-engine', () => {
+  let instance: ChessEngineInterface;
+  
+  beforeEach(async () => {
+    // Create a fresh instance before each test
+    instance = createChessEngine({
+      debug: true,
+      name: 'test-chess-engine'
+    });
+    
+    // Initialize the instance
+    await instance.initialize();
+  });
+  
+  afterEach(async () => {
+    // Clean up after each test
+    await instance.terminate();
+  });
+  
+  describe('Lifecycle Management', () => {
+    test('should initialize correctly', () => {
+      const state = instance.getState();
+      expect(state.lifecycle).toBe(ModelLifecycleState.Ready);
+    });
+    
+    test('should reset state', async () => {
+      // Perform some operations
+      await instance.process('test-data');
+      
+      // Reset the instance
+      const result = await instance.reset();
+      expect(result.success).toBe(true);
+      
+      // Check state after reset
+      const state = instance.getState();
+      expect(state.operationCount.total).toBe(0);
+    });
+    
+    test('should terminate properly', async () => {
+      const result = await instance.terminate();
+      expect(result.success).toBe(true);
+      
+      const state = instance.getState();
+      expect(state.lifecycle).toBe(ModelLifecycleState.Terminated);
+    });
+  });
+  
+  describe('Basic functionality', () => {
+    test('should process input data', async () => {
+      const testInput = 'test-data';
+      const result = await instance.process(testInput);
+      
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.timestamp).toBeDefined();
+    });
+    
+    test('should access logger', () => {
+      const logger = instance.getLogger();
+      expect(logger).toBeDefined();
+      expect(typeof logger.info).toBe('function');
+    });
+    
+    test('should handle custom state', async () => {
+      const state = instance.getState();
+      expect(state.custom).toBeDefined();
+      
+      // Add assertions specific to module's custom state
+    });
+  });
+  
+  describe('Configuration options', () => {
+    test('should use default options when none provided', async () => {
+      const defaultInstance = createChessEngine();
+      await defaultInstance.initialize();
+      
+      expect(defaultInstance).toBeDefined();
+      
+      await defaultInstance.terminate();
+    });
+    
+    test('should respect custom options', async () => {
+      const customOptions: ChessEngineOptions = {
+        debug: true,
+        name: 'custom-chess-engine',
+        version: '1.2.3',
+        // Add more custom options as needed
+      };
+      
+      const customInstance = createChessEngine(customOptions);
+      await customInstance.initialize();
+      
+      // Process something to get a result with source
+      const result = await customInstance.process('test');
+      expect(result.source).toContain('custom-chess-engine');
+      expect(result.source).toContain('1.2.3');
+      
+      await customInstance.terminate();
+    });
+  });
+  
+  describe('Error handling', () => {
+    test('should handle processing errors gracefully', async () => {
+      // Create a bad input that will cause an error
+      // This is just a placeholder - you may need to adjust for your specific module
+      const badInput = undefined;
+      
+      // Process should not throw but return error result
+      const result = await instance.process(badInput as any);
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+  
+  // Template placeholder: Add more test suites specific to the module
+  describe('Module-specific functionality', () => {
+    test('should implement module-specific features', () => {
+      // This is a placeholder for module-specific tests
+      // Replace with actual tests for the module's features
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/kernel/chess-engine/types.ts
+++ b/kernel/chess-engine/types.ts
@@ -1,0 +1,55 @@
+/**
+ * chess-engine Types
+ * ============
+ * 
+ * Type definitions for the chess-engine module.
+ */
+
+import {
+  ModelOptions,
+  ModelInterface,
+  ModelResult,
+  ModelState,
+  ModelLifecycleState
+} from '../os/model/types';
+import { LoggingInterface } from '../os/logging';
+
+/**
+ * Configuration options for chess-engine
+ */
+export interface ChessEngineOptions extends ModelOptions {
+  /**
+   * Module-specific options go here
+   */
+  // Add module-specific options here
+}
+
+/**
+ * Core interface for chess-engine functionality
+ */
+export interface ChessEngineInterface extends ModelInterface {
+  /**
+   * Module-specific methods go here
+   */
+  // Add module-specific methods here
+  
+  /**
+   * Access the module logger
+   */
+  getLogger(): LoggingInterface;
+}
+
+/**
+ * Result of chess-engine operations
+ */
+export type ChessEngineResult<T = unknown> = ModelResult<T>;
+
+/**
+ * Extended state for chess-engine module
+ */
+export interface ChessEngineState extends ModelState {
+  /**
+   * Module-specific state properties go here
+   */
+  // Add module-specific state properties here
+}

--- a/os/apps/chess/README.md
+++ b/os/apps/chess/README.md
@@ -1,0 +1,135 @@
+# chess
+
+Chess implementation for PrimeOS
+
+## Overview
+
+This module follows the standard PrimeOS module pattern, implementing the PrimeOS Model interface for consistent lifecycle management, state tracking, error handling, and integrated logging.
+
+## Features
+
+- Fully integrates with the PrimeOS model system
+- Built-in logging capabilities
+- Standard lifecycle management (initialize, process, reset, terminate)
+- Automatic error handling and result formatting
+
+## Installation
+
+```bash
+npm install chess
+```
+
+## Usage
+
+```typescript
+import { createChess } from 'chess';
+
+// Create an instance
+const instance = createChess({
+  debug: true,
+  name: 'chess-instance',
+  version: '1.0.0'
+});
+
+// Initialize the module
+await instance.initialize();
+
+// Process data
+const result = await instance.process('example-input');
+console.log(result);
+
+// Clean up when done
+await instance.terminate();
+```
+
+## API
+
+### `createChess(options)`
+
+Creates a new chess instance with the specified options.
+
+Parameters:
+- `options` - Optional configuration options
+
+Returns:
+- A chess instance implementing ChessInterface
+
+### ChessInterface
+
+The main interface implemented by chess. Extends the ModelInterface.
+
+Methods:
+- `initialize()` - Initialize the module (required before processing)
+- `process<T, R>(input: T)` - Process the input data and return a result
+- `reset()` - Reset the module to its initial state
+- `terminate()` - Release resources and shut down the module
+- `getState()` - Get the current module state
+- `getLogger()` - Get the module's logger instance
+
+### Options
+
+Configuration options for chess:
+
+```typescript
+interface ChessOptions {
+  // Enable debug mode
+  debug?: boolean;
+  
+  // Module name
+  name?: string;
+  
+  // Module version
+  version?: string;
+  
+  // Module-specific options
+  // ...
+}
+```
+
+### Result Format
+
+All operations return a standardized result format:
+
+```typescript
+{
+  success: true,          // Success indicator
+  data: { ... },          // Operation result data
+  timestamp: 1620000000,  // Operation timestamp
+  source: 'module-name'   // Source module
+}
+```
+
+## Lifecycle Management
+
+The module follows a defined lifecycle:
+
+1. **Uninitialized**: Initial state when created
+2. **Initializing**: During setup and resource allocation
+3. **Ready**: Available for processing
+4. **Processing**: Actively handling an operation
+5. **Error**: Encountered an issue
+6. **Terminating**: During resource cleanup
+7. **Terminated**: Final state after cleanup
+
+Always follow this sequence:
+1. Create the module with `createChess`
+2. Initialize with `initialize()`
+3. Process data with `process()`
+4. Clean up with `terminate()`
+
+## Custom Implementation
+
+You can extend the functionality by adding module-specific methods to the implementation.
+
+## Error Handling
+
+Errors are automatically caught and returned in a standardized format:
+
+```typescript
+{
+  success: false,
+  error: "Error message",
+  timestamp: 1620000000,
+  source: "module-name"
+}
+```

--- a/os/apps/chess/index.ts
+++ b/os/apps/chess/index.ts
@@ -1,0 +1,111 @@
+/**
+ * chess Implementation
+ * =====
+ * 
+ * This module implements Chess implementation for PrimeOS.
+ * It follows the standard PrimeOS model pattern.
+ */
+
+import {
+  BaseModel,
+  ModelResult,
+  ModelLifecycleState,
+  createAndInitializeModel
+} from '../os/model';
+import {
+  ChessOptions,
+  ChessInterface,
+  ChessState
+} from './types';
+
+/**
+ * Default options for chess
+ */
+const DEFAULT_OPTIONS: ChessOptions = {
+  debug: false,
+  name: 'chess',
+  version: '0.1.0'
+};
+
+/**
+ * Main implementation of chess
+ */
+export class ChessImplementation extends BaseModel implements ChessInterface {
+  /**
+   * Create a new chess instance
+   */
+  constructor(options: ChessOptions = {}) {
+    // Initialize BaseModel with options
+    super({ ...DEFAULT_OPTIONS, ...options });
+    
+    // Add any custom initialization here
+  }
+  
+  /**
+   * Module-specific initialization logic
+   */
+  protected async onInitialize(): Promise<void> {
+    // Custom initialization logic goes here
+    
+    // Add custom state if needed
+    this.state.custom = {
+      // Add module-specific state properties here
+    };
+    
+    // Log initialization
+    await this.logger.debug('Chess initialized with options', this.options);
+  }
+  
+  /**
+   * Process input data with module-specific logic
+   */
+  protected async onProcess<T = unknown, R = unknown>(input: T): Promise<R> {
+    await this.logger.debug('Processing input in Chess', input);
+    
+    // TODO: Implement actual processing logic here
+    // This is just a placeholder - replace with real implementation
+    const result = input as unknown as R;
+    
+    return result;
+  }
+  
+  /**
+   * Clean up resources when module is reset
+   */
+  protected async onReset(): Promise<void> {
+    // Clean up any module-specific resources
+    await this.logger.debug('Resetting Chess');
+  }
+  
+  /**
+   * Clean up resources when module is terminated
+   */
+  protected async onTerminate(): Promise<void> {
+    // Release any module-specific resources
+    await this.logger.debug('Terminating Chess');
+  }
+}
+
+/**
+ * Create a chess instance with the specified options
+ */
+export function createChess(options: ChessOptions = {}): ChessInterface {
+  return new ChessImplementation(options);
+}
+
+/**
+ * Create and initialize a chess instance in a single step
+ */
+export async function createAndInitializeChess(options: ChessOptions = {}): Promise<ChessInterface> {
+  const instance = createChess(options);
+  const result = await instance.initialize();
+  
+  if (!result.success) {
+    throw new Error(`Failed to initialize chess: ${result.error}`);
+  }
+  
+  return instance;
+}
+
+// Export types
+export * from './types';

--- a/os/apps/chess/package.json
+++ b/os/apps/chess/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "chess",
+  "version": "0.1.0",
+  "description": "Chess implementation for PrimeOS",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write \"**/*.ts\""
+  },
+  "keywords": [
+    "primeos",
+    "chess"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "primeos": "^0.1.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.3",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.1.6"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
+  }
+}

--- a/os/apps/chess/test.ts
+++ b/os/apps/chess/test.ts
@@ -1,0 +1,138 @@
+/**
+ * chess Tests
+ * =====
+ * 
+ * Test suite for the chess module.
+ */
+
+import { 
+  createChess,
+  ChessInterface,
+  ChessOptions,
+  ChessState
+} from './index';
+import { ModelLifecycleState } from '../os/model';
+
+describe('chess', () => {
+  let instance: ChessInterface;
+  
+  beforeEach(async () => {
+    // Create a fresh instance before each test
+    instance = createChess({
+      debug: true,
+      name: 'test-chess'
+    });
+    
+    // Initialize the instance
+    await instance.initialize();
+  });
+  
+  afterEach(async () => {
+    // Clean up after each test
+    await instance.terminate();
+  });
+  
+  describe('Lifecycle Management', () => {
+    test('should initialize correctly', () => {
+      const state = instance.getState();
+      expect(state.lifecycle).toBe(ModelLifecycleState.Ready);
+    });
+    
+    test('should reset state', async () => {
+      // Perform some operations
+      await instance.process('test-data');
+      
+      // Reset the instance
+      const result = await instance.reset();
+      expect(result.success).toBe(true);
+      
+      // Check state after reset
+      const state = instance.getState();
+      expect(state.operationCount.total).toBe(0);
+    });
+    
+    test('should terminate properly', async () => {
+      const result = await instance.terminate();
+      expect(result.success).toBe(true);
+      
+      const state = instance.getState();
+      expect(state.lifecycle).toBe(ModelLifecycleState.Terminated);
+    });
+  });
+  
+  describe('Basic functionality', () => {
+    test('should process input data', async () => {
+      const testInput = 'test-data';
+      const result = await instance.process(testInput);
+      
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.timestamp).toBeDefined();
+    });
+    
+    test('should access logger', () => {
+      const logger = instance.getLogger();
+      expect(logger).toBeDefined();
+      expect(typeof logger.info).toBe('function');
+    });
+    
+    test('should handle custom state', async () => {
+      const state = instance.getState();
+      expect(state.custom).toBeDefined();
+      
+      // Add assertions specific to module's custom state
+    });
+  });
+  
+  describe('Configuration options', () => {
+    test('should use default options when none provided', async () => {
+      const defaultInstance = createChess();
+      await defaultInstance.initialize();
+      
+      expect(defaultInstance).toBeDefined();
+      
+      await defaultInstance.terminate();
+    });
+    
+    test('should respect custom options', async () => {
+      const customOptions: ChessOptions = {
+        debug: true,
+        name: 'custom-chess',
+        version: '1.2.3',
+        // Add more custom options as needed
+      };
+      
+      const customInstance = createChess(customOptions);
+      await customInstance.initialize();
+      
+      // Process something to get a result with source
+      const result = await customInstance.process('test');
+      expect(result.source).toContain('custom-chess');
+      expect(result.source).toContain('1.2.3');
+      
+      await customInstance.terminate();
+    });
+  });
+  
+  describe('Error handling', () => {
+    test('should handle processing errors gracefully', async () => {
+      // Create a bad input that will cause an error
+      // This is just a placeholder - you may need to adjust for your specific module
+      const badInput = undefined;
+      
+      // Process should not throw but return error result
+      const result = await instance.process(badInput as any);
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+  
+  // Template placeholder: Add more test suites specific to the module
+  describe('Module-specific functionality', () => {
+    test('should implement module-specific features', () => {
+      // This is a placeholder for module-specific tests
+      // Replace with actual tests for the module's features
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/os/apps/chess/types.ts
+++ b/os/apps/chess/types.ts
@@ -1,0 +1,55 @@
+/**
+ * chess Types
+ * =====
+ * 
+ * Type definitions for the chess module.
+ */
+
+import {
+  ModelOptions,
+  ModelInterface,
+  ModelResult,
+  ModelState,
+  ModelLifecycleState
+} from '../os/model/types';
+import { LoggingInterface } from '../os/logging';
+
+/**
+ * Configuration options for chess
+ */
+export interface ChessOptions extends ModelOptions {
+  /**
+   * Module-specific options go here
+   */
+  // Add module-specific options here
+}
+
+/**
+ * Core interface for chess functionality
+ */
+export interface ChessInterface extends ModelInterface {
+  /**
+   * Module-specific methods go here
+   */
+  // Add module-specific methods here
+  
+  /**
+   * Access the module logger
+   */
+  getLogger(): LoggingInterface;
+}
+
+/**
+ * Result of chess operations
+ */
+export type ChessResult<T = unknown> = ModelResult<T>;
+
+/**
+ * Extended state for chess module
+ */
+export interface ChessState extends ModelState {
+  /**
+   * Module-specific state properties go here
+   */
+  // Add module-specific state properties here
+}


### PR DESCRIPTION
## Summary
- generate skeletons for `chess-core`, `chess-engine`, and `chess` modules
- add README, package.json, types, index, and tests for each module

## Testing
- `node os/model/create-module.js --name=chess-core --path=core`
- `node os/model/create-module.js --name=chess-engine --path=kernel`
- `node os/model/create-module.js --name=chess --path=os/apps`


------
https://chatgpt.com/codex/tasks/task_b_6845b4bc17b88320a4b3a95069670b66