### PR TITLE
Implement prime based chess board encoding

### DIFF
--- a/core/chess-core/board.test.ts
+++ b/core/chess-core/board.test.ts
@@ -1,0 +1,26 @@
+import { initializePrimeMappings, getMappings } from './primes';
+import { fenToBoardState, boardStateToFen, encodeBoard, decodeBoard } from './board';
+import { ChessPiece } from './types';
+
+describe('board encoding', () => {
+  beforeAll(async () => {
+    await initializePrimeMappings();
+  });
+
+  test('deterministic prime mapping', () => {
+    const { pieceSquare, primeLookup } = getMappings();
+    const prime = pieceSquare[ChessPiece.WhitePawn]['a2'];
+    const mapping = primeLookup[prime.toString()];
+    expect(mapping.piece).toBe(ChessPiece.WhitePawn);
+    expect(mapping.square).toBe('a2');
+  });
+
+  test('round-trip encode/decode', async () => {
+    const fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+    const state = fenToBoardState(fen);
+    const encoded = await encodeBoard(state);
+    const decoded = await decodeBoard(encoded);
+    const fen2 = boardStateToFen({ ...decoded, activeColor: state.activeColor, castling: state.castling, enPassant: state.enPassant, halfmove: state.halfmove, fullmove: state.fullmove });
+    expect(fen2).toBe(fen);
+  });
+});

--- a/core/chess-core/board.ts
+++ b/core/chess-core/board.ts
@@ -1,0 +1,111 @@
+import { BoardState, ChessPiece, Square } from './types';
+import { getPrimeRegistry, getMappings, initializePrimeMappings } from './primes';
+
+/** Ensure that prime mappings are initialized */
+async function ensureInitialized(): Promise<void> {
+  try {
+    getMappings();
+  } catch {
+    await initializePrimeMappings();
+  }
+}
+
+/**
+ * Encode a board state into a bigint using prime multiplication.
+ */
+export async function encodeBoard(state: BoardState): Promise<bigint> {
+  await ensureInitialized();
+  const { pieceSquare } = getMappings();
+  let value = 1n;
+  for (const [square, piece] of Object.entries(state.pieces)) {
+    if (!piece) continue;
+    value *= pieceSquare[piece as ChessPiece][square as Square];
+  }
+  return value;
+}
+
+/**
+ * Decode a bigint back into a board state by prime factorization.
+ */
+export async function decodeBoard(encoded: bigint): Promise<BoardState> {
+  await ensureInitialized();
+  const registry = getPrimeRegistry();
+  const { primeLookup } = getMappings();
+  const factors = registry.factor(encoded);
+
+  const pieces: Partial<Record<Square, ChessPiece>> = {};
+  for (const { prime } of factors) {
+    const mapping = primeLookup[prime.toString()];
+    if (mapping) {
+      pieces[mapping.square] = mapping.piece;
+    }
+  }
+
+  return {
+    pieces,
+    activeColor: 'w',
+    castling: '-',
+    enPassant: null,
+    halfmove: 0,
+    fullmove: 1
+  };
+}
+
+const FILES = ['a','b','c','d','e','f','g','h'] as const;
+
+/** Convert a FEN string to a BoardState */
+export function fenToBoardState(fen: string): BoardState {
+  const [placement, active='w', castling='-', ep='-', half='0', full='1'] = fen.trim().split(/\s+/);
+  const pieces: Partial<Record<Square, ChessPiece>> = {};
+  const rows = placement.split('/');
+  for (let r = 0; r < 8; r++) {
+    const rankStr = rows[r];
+    let fileIdx = 0;
+    for (const ch of rankStr) {
+      if (/[1-8]/.test(ch)) {
+        fileIdx += parseInt(ch, 10);
+      } else {
+        const square = `${FILES[fileIdx]}${8 - r}` as Square;
+        pieces[square] = ch as ChessPiece;
+        fileIdx += 1;
+      }
+    }
+  }
+  return {
+    pieces,
+    activeColor: active as 'w' | 'b',
+    castling,
+    enPassant: ep === '-' ? null : ep as Square,
+    halfmove: parseInt(half, 10),
+    fullmove: parseInt(full, 10)
+  };
+}
+
+/** Convert a BoardState back into a FEN string */
+export function boardStateToFen(state: BoardState): string {
+  const rows: string[] = [];
+  for (let r = 7; r >= 0; r--) {
+    let empty = 0;
+    let row = '';
+    for (let f = 0; f < 8; f++) {
+      const square = `${FILES[f]}${r+1}` as Square;
+      const piece = state.pieces[square];
+      if (!piece) {
+        empty++;
+      } else {
+        if (empty > 0) { row += String(empty); empty = 0; }
+        row += piece;
+      }
+    }
+    if (empty > 0) row += String(empty);
+    rows.push(row);
+  }
+
+  const placement = rows.join('/');
+  const active = state.activeColor;
+  const castling = state.castling || '-';
+  const ep = state.enPassant || '-';
+  const half = state.halfmove.toString();
+  const full = state.fullmove.toString();
+  return `${placement} ${active} ${castling} ${ep} ${half} ${full}`;
+}

--- a/core/chess-core/index.ts
+++ b/core/chess-core/index.ts
@@ -109,3 +109,5 @@ export async function createAndInitializeChessCore(options: ChessCoreOptions = {
 
 // Export types
 export * from './types';
+export * from './board';
+export * from './primes';

--- a/core/chess-core/primes.ts
+++ b/core/chess-core/primes.ts
@@ -1,0 +1,47 @@
+import { createAndInitializePrimeRegistry, PrimeRegistryInterface } from '../prime';
+import { ChessPiece, Square } from './types';
+
+export interface PrimeMappings {
+  pieceSquare: Record<ChessPiece, Record<Square, bigint>>;
+  primeLookup: Record<string, { piece: ChessPiece; square: Square }>;
+}
+
+let registry: PrimeRegistryInterface | null = null;
+let mappings: PrimeMappings | null = null;
+let initialized = false;
+
+export async function initializePrimeMappings(): Promise<void> {
+  if (initialized) return;
+  registry = await createAndInitializePrimeRegistry({ preloadCount: 1000 });
+  const pieceSquare: Record<ChessPiece, Record<Square, bigint>> = {} as any;
+  const primeLookup: Record<string, { piece: ChessPiece; square: Square }> = {};
+
+  const files = ['a','b','c','d','e','f','g','h'] as const;
+  const ranks = [1,2,3,4,5,6,7,8] as const;
+  let index = 0;
+
+  for (const piece of Object.values(ChessPiece)) {
+    pieceSquare[piece] = {} as Record<Square, bigint>;
+    for (const r of ranks) {
+      for (const f of files) {
+        const sq = `${f}${r}` as Square;
+        const prime = registry.getPrime(index++);
+        pieceSquare[piece][sq] = prime;
+        primeLookup[prime.toString()] = { piece, square: sq };
+      }
+    }
+  }
+
+  mappings = { pieceSquare, primeLookup };
+  initialized = true;
+}
+
+export function getPrimeRegistry(): PrimeRegistryInterface {
+  if (!registry) throw new Error('Prime mappings not initialized');
+  return registry;
+}
+
+export function getMappings(): PrimeMappings {
+  if (!mappings) throw new Error('Prime mappings not initialized');
+  return mappings;
+}

--- a/core/chess-core/types.ts
+++ b/core/chess-core/types.ts
@@ -53,3 +53,59 @@ export interface ChessCoreState extends ModelState {
    */
   // Add module-specific state properties here
 }
+
+/**
+ * Enumeration of all chess pieces using standard FEN notation
+ */
+export enum ChessPiece {
+  WhitePawn = 'P',
+  WhiteKnight = 'N',
+  WhiteBishop = 'B',
+  WhiteRook = 'R',
+  WhiteQueen = 'Q',
+  WhiteKing = 'K',
+  BlackPawn = 'p',
+  BlackKnight = 'n',
+  BlackBishop = 'b',
+  BlackRook = 'r',
+  BlackQueen = 'q',
+  BlackKing = 'k'
+}
+
+/**
+ * Algebraic board coordinate like `a1` or `h8`
+ */
+export type Square = `${'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h'}${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8}`;
+
+/**
+ * Representation of a full chess board state.
+ * Only information needed for FEN conversion is included.
+ */
+export interface BoardState {
+  /** Mapping of squares to pieces (omitted squares are empty) */
+  pieces: Partial<Record<Square, ChessPiece>>;
+
+  /** which side is to move */
+  activeColor: 'w' | 'b';
+
+  /** castling rights string e.g. "KQkq" or '-' */
+  castling: string;
+
+  /** en-passant target square or null */
+  enPassant: Square | null;
+
+  /** halfmove clock */
+  halfmove: number;
+
+  /** fullmove number */
+  fullmove: number;
+}
+
+/**
+ * Basic chess move
+ */
+export interface ChessMove {
+  from: Square;
+  to: Square;
+  promotion?: ChessPiece;
+}


### PR DESCRIPTION
## Summary
- define board/engine types for chess-core
- create registry-based prime mappings for pieces and squares
- add board encoding and FEN conversion helpers
- expose new helpers from chess-core package
- test deterministic mapping and round-trip encoding

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845b5a69aa08320be23188acc610ba4