### PR TITLE
Add chess CLI wrapper

### DIFF
--- a/os/apps/chess/types.ts
+++ b/os/apps/chess/types.ts
@@ -18,20 +18,22 @@ import { LoggingInterface } from '../os/logging';
  * Configuration options for chess
  */
 export interface ChessOptions extends ModelOptions {
-  /**
-   * Module-specific options go here
-   */
-  // Add module-specific options here
+  /** Play mode: human vs machine or machine vs machine */
+  mode?: 'human' | 'auto';
+
+  /** Number of half-moves to play in auto mode */
+  depth?: number;
+
+  /** Optional path to training dataset */
+  train?: string;
 }
 
 /**
  * Core interface for chess functionality
  */
 export interface ChessInterface extends ModelInterface {
-  /**
-   * Module-specific methods go here
-   */
-  // Add module-specific methods here
+  /** Run the CLI play loop */
+  play(): Promise<void>;
   
   /**
    * Access the module logger
@@ -48,8 +50,6 @@ export type ChessResult<T = unknown> = ModelResult<T>;
  * Extended state for chess module
  */
 export interface ChessState extends ModelState {
-  /**
-   * Module-specific state properties go here
-   */
-  // Add module-specific state properties here
+  /** Current board position in FEN notation */
+  board?: string;
 }

--- a/os/apps/index.ts
+++ b/os/apps/index.ts
@@ -7,4 +7,5 @@
  */
 
 export * from './hanoi';
+export * from './chess';
 

--- a/os/os-tests/chess-cli.test.ts
+++ b/os/os-tests/chess-cli.test.ts
@@ -1,0 +1,29 @@
+import { createAndInitializeChess } from '../apps/chess';
+
+/** capture logs and return them */
+function captureLogs(fn: () => Promise<void>): Promise<string[]> {
+  const logs: string[] = [];
+  const orig = console.log;
+  console.log = (...args: any[]) => { logs.push(args.join(' ')); };
+  return fn().then(() => {
+    console.log = orig;
+    return logs;
+  }, err => {
+    console.log = orig;
+    throw err;
+  });
+}
+
+describe('chess cli integration', () => {
+  test('machine vs machine logs are deterministic', async () => {
+    const chess = await createAndInitializeChess({ mode: 'auto', depth: 2 });
+    const logs = await captureLogs(() => chess.play());
+    await chess.terminate();
+    expect(logs).toEqual([
+      'move 1: a2a3',
+      'rnbqkbnr/pppppppp/8/8/8/P7/1PPPPPPP/RNBQKBNR b KQkq - 0 1',
+      'move 2: a7a6',
+      'rnbqkbnr/1ppppppp/p7/8/8/P7/1PPPPPPP/RNBQKBNR w KQkq - 0 1'
+    ]);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
-import { createAndInitializeHanoi } from '../os/apps/hanoi';
+import { createAndInitializeChess } from '../os/apps/chess';
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const opts: { disks?: number; auto: boolean } = { auto: false };
+  const opts: { mode?: 'human' | 'auto'; depth?: number; train?: string } = {};
   for (const a of args) {
-    if (a.startsWith('--disks=')) {
-      opts.disks = parseInt(a.split('=')[1], 10);
-    } else if (a === '--auto') {
-      opts.auto = true;
-    } else if (a === '--no-auto') {
-      opts.auto = false;
+    if (a.startsWith('--mode=')) {
+      opts.mode = a.split('=')[1] as 'human' | 'auto';
+    } else if (a.startsWith('--depth=')) {
+      opts.depth = parseInt(a.split('=')[1], 10);
+    } else if (a.startsWith('--train=')) {
+      opts.train = a.split('=')[1];
     }
   }
   return opts;
@@ -18,15 +18,9 @@ function parseArgs() {
 
 async function main() {
   const opts = parseArgs();
-  const hanoi = await createAndInitializeHanoi({ disks: opts.disks });
-
-  if (opts.auto) {
-    await hanoi.solve();
-  }
-
-  console.log(JSON.stringify(hanoi.getState().towers));
-  console.log(`Moves: ${hanoi.getState().moves.length}`);
-  await hanoi.terminate();
+  const chess = await createAndInitializeChess(opts);
+  await chess.play();
+  await chess.terminate();
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- implement CLI-driven chess app using BaseModel
- export chess module from os/apps
- update overall CLI to run chess app
- integrate chess-engine for gameplay
- add deterministic integration test for automated chess matches

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845b860b2a48320a00de850ae89b612