### PR TITLE
Fix module paths for hanoi app

### DIFF
--- a/os/apps/hanoi/index.ts
+++ b/os/apps/hanoi/index.ts
@@ -9,7 +9,7 @@
 import {
   BaseModel,
   ModelResult
-} from '../model';
+} from '../../model';
 import {
   HanoiOptions,
   HanoiInterface,

--- a/os/apps/hanoi/test.ts
+++ b/os/apps/hanoi/test.ts
@@ -6,7 +6,7 @@ import {
   TestResults,
   TestMetadata,
   TestResultStatus
-} from '../os-tests';
+} from '../../os-tests';
 
 export default class HanoiTests implements TestableInterface {
   validateBase(): TestResult {

--- a/os/apps/hanoi/types.ts
+++ b/os/apps/hanoi/types.ts
@@ -10,8 +10,8 @@ import {
   ModelInterface,
   ModelResult,
   ModelState
-} from '../model/types';
-import { LoggingInterface } from '../os/logging';
+} from '../../model/types';
+import { LoggingInterface } from '../../logging';
 
 /**
  * Configuration options for hanoi


### PR DESCRIPTION
## Summary
- fix relative import paths in `os/apps/hanoi`
- run TypeScript compilation for the hanoi package

## Testing
- `npx tsc -p os/apps/hanoi` *(fails: Cannot find a tsconfig.json file at the specified directory)*

------
https://chatgpt.com/codex/tasks/task_b_6845ba24ed308320bebdd8360f9c6c39