### PR TITLE
Document chess modules

### DIFF
--- a/core/chess-core/README.md
+++ b/core/chess-core/README.md
@@ -1,17 +1,6 @@
 # chess-core
 
-ChessCore implementation for PrimeOS
-
-## Overview
-
-This module follows the standard PrimeOS module pattern, implementing the PrimeOS Model interface for consistent lifecycle management, state tracking, error handling, and integrated logging.
-
-## Features
-
-- Fully integrates with the PrimeOS model system
-- Built-in logging capabilities
-- Standard lifecycle management (initialize, process, reset, terminate)
-- Automatic error handling and result formatting
+Low level chess utilities for PrimeOS. The module provides deterministic prime-based encoding for board states and helpers for converting to and from FEN notation.
 
 ## Installation
 
@@ -22,114 +11,39 @@ npm install chess-core
 ## Usage
 
 ```typescript
-import { createChessCore } from 'chess-core';
+import {
+  fenToBoardState,
+  boardStateToFen,
+  encodeBoard,
+  decodeBoard
+} from 'chess-core';
 
-// Create an instance
-const instance = createChessCore({
-  debug: true,
-  name: 'chess-core-instance',
-  version: '1.0.0'
-});
+// convert FEN to structured board
+const state = fenToBoardState('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1');
 
-// Initialize the module
-await instance.initialize();
+// encode board into a bigint using prime factors
+const encoded = await encodeBoard(state);
 
-// Process data
-const result = await instance.process('example-input');
-console.log(result);
-
-// Clean up when done
-await instance.terminate();
+// decode back to board state
+const roundTrip = await decodeBoard(encoded);
+console.log(boardStateToFen(roundTrip)); // original FEN
 ```
 
 ## API
 
-### `createChessCore(options)`
+### `fenToBoardState(fen: string): BoardState`
+Convert a FEN string into a structured `BoardState` object.
 
-Creates a new chess-core instance with the specified options.
+### `boardStateToFen(state: BoardState): string`
+Convert a `BoardState` back into FEN notation.
 
-Parameters:
-- `options` - Optional configuration options
+### `encodeBoard(state: BoardState): Promise<bigint>`
+Returns a bigint obtained by multiplying the unique primes assigned to each piece/square pair.
 
-Returns:
-- A chess-core instance implementing ChessCoreInterface
+### `decodeBoard(encoded: bigint): Promise<BoardState>`
+Factorizes the bigint back into the corresponding board state.
 
-### ChessCoreInterface
+### Deterministic Behaviour
 
-The main interface implemented by chess-core. Extends the ModelInterface.
+Prime mappings are generated once by the prime registry. Each piece/square pair always maps to the same prime, so encoding and decoding yield the exact same result across runs. This deterministic representation is used by higher layers such as `chess-engine` for reproducible state evaluation.
 
-Methods:
-- `initialize()` - Initialize the module (required before processing)
-- `process<T, R>(input: T)` - Process the input data and return a result
-- `reset()` - Reset the module to its initial state
-- `terminate()` - Release resources and shut down the module
-- `getState()` - Get the current module state
-- `getLogger()` - Get the module's logger instance
-
-### Options
-
-Configuration options for chess-core:
-
-```typescript
-interface ChessCoreOptions {
-  // Enable debug mode
-  debug?: boolean;
-  
-  // Module name
-  name?: string;
-  
-  // Module version
-  version?: string;
-  
-  // Module-specific options
-  // ...
-}
-```
-
-### Result Format
-
-All operations return a standardized result format:
-
-```typescript
-{
-  success: true,          // Success indicator
-  data: { ... },          // Operation result data
-  timestamp: 1620000000,  // Operation timestamp
-  source: 'module-name'   // Source module
-}
-```
-
-## Lifecycle Management
-
-The module follows a defined lifecycle:
-
-1. **Uninitialized**: Initial state when created
-2. **Initializing**: During setup and resource allocation
-3. **Ready**: Available for processing
-4. **Processing**: Actively handling an operation
-5. **Error**: Encountered an issue
-6. **Terminating**: During resource cleanup
-7. **Terminated**: Final state after cleanup
-
-Always follow this sequence:
-1. Create the module with `createChessCore`
-2. Initialize with `initialize()`
-3. Process data with `process()`
-4. Clean up with `terminate()`
-
-## Custom Implementation
-
-You can extend the functionality by adding module-specific methods to the implementation.
-
-## Error Handling
-
-Errors are automatically caught and returned in a standardized format:
-
-```typescript
-{
-  success: false,
-  error: "Error message",
-  timestamp: 1620000000,
-  source: "module-name"
-}
-```

--- a/kernel/chess-engine/README.md
+++ b/kernel/chess-engine/README.md
@@ -1,17 +1,6 @@
 # chess-engine
 
-ChessEngine implementation for PrimeOS
-
-## Overview
-
-This module follows the standard PrimeOS module pattern, implementing the PrimeOS Model interface for consistent lifecycle management, state tracking, error handling, and integrated logging.
-
-## Features
-
-- Fully integrates with the PrimeOS model system
-- Built-in logging capabilities
-- Standard lifecycle management (initialize, process, reset, terminate)
-- Automatic error handling and result formatting
+The evaluation engine for PrimeOS chess. It builds on `chess-core` for board representation and uses the UOR virtual machine to run prime-encoded evaluation programs.
 
 ## Installation
 
@@ -22,114 +11,31 @@ npm install chess-engine
 ## Usage
 
 ```typescript
-import { createChessEngine } from 'chess-engine';
+import { createAndInitializeChessEngine } from 'chess-engine';
+import { fenToBoardState } from 'chess-core';
 
-// Create an instance
-const instance = createChessEngine({
-  debug: true,
-  name: 'chess-engine-instance',
-  version: '1.0.0'
-});
+const engine = await createAndInitializeChessEngine();
+await engine.loadPosition(fenToBoardState('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'));
 
-// Initialize the module
-await instance.initialize();
-
-// Process data
-const result = await instance.process('example-input');
-console.log(result);
-
-// Clean up when done
-await instance.terminate();
+const best = await engine.computeMove();
+console.log(best);
+await engine.applyMove(best!);
 ```
 
 ## API
 
-### `createChessEngine(options)`
+- **`createChessEngine(options?)`** – create a new engine instance.
+- **`createAndInitializeChessEngine(options?)`** – helper that also calls `initialize()`.
+- **`computeMove(): Promise<ChessMove | null>`** – deterministically calculates the best move for the current board.
+- **`applyMove(move: ChessMove): Promise<void>`** – apply a move to the internal board.
+- **`loadPosition(board: BoardState): Promise<void>`** – replace the current board state.
+- **`train(dataset: ChessGame[]): Promise<void>`** – adjust the evaluation table.
 
-Creates a new chess-engine instance with the specified options.
+### Deterministic Behaviour
 
-Parameters:
-- `options` - Optional configuration options
+`computeMove()` relies on the prime-based board encoding from `chess-core` combined with evaluation programs executed through the `EnhancedChunkVM`. Given the same position and training data the output move is always the same, ensuring reproducible results.
 
-Returns:
-- A chess-engine instance implementing ChessEngineInterface
+### Prime Encoding and UOR VM
 
-### ChessEngineInterface
+Moves and evaluation routines are expressed as arrays of prime encoded chunks. These chunks are executed by the UOR virtual machine (`EnhancedChunkVM`), which interprets standard opcodes such as `OP_PUSH`, `OP_ADD` and extended instructions. The VM's deterministic stack execution, together with the fixed prime mapping, guarantees consistent behaviour on any platform.
 
-The main interface implemented by chess-engine. Extends the ModelInterface.
-
-Methods:
-- `initialize()` - Initialize the module (required before processing)
-- `process<T, R>(input: T)` - Process the input data and return a result
-- `reset()` - Reset the module to its initial state
-- `terminate()` - Release resources and shut down the module
-- `getState()` - Get the current module state
-- `getLogger()` - Get the module's logger instance
-
-### Options
-
-Configuration options for chess-engine:
-
-```typescript
-interface ChessEngineOptions {
-  // Enable debug mode
-  debug?: boolean;
-  
-  // Module name
-  name?: string;
-  
-  // Module version
-  version?: string;
-  
-  // Module-specific options
-  // ...
-}
-```
-
-### Result Format
-
-All operations return a standardized result format:
-
-```typescript
-{
-  success: true,          // Success indicator
-  data: { ... },          // Operation result data
-  timestamp: 1620000000,  // Operation timestamp
-  source: 'module-name'   // Source module
-}
-```
-
-## Lifecycle Management
-
-The module follows a defined lifecycle:
-
-1. **Uninitialized**: Initial state when created
-2. **Initializing**: During setup and resource allocation
-3. **Ready**: Available for processing
-4. **Processing**: Actively handling an operation
-5. **Error**: Encountered an issue
-6. **Terminating**: During resource cleanup
-7. **Terminated**: Final state after cleanup
-
-Always follow this sequence:
-1. Create the module with `createChessEngine`
-2. Initialize with `initialize()`
-3. Process data with `process()`
-4. Clean up with `terminate()`
-
-## Custom Implementation
-
-You can extend the functionality by adding module-specific methods to the implementation.
-
-## Error Handling
-
-Errors are automatically caught and returned in a standardized format:
-
-```typescript
-{
-  success: false,
-  error: "Error message",
-  timestamp: 1620000000,
-  source: "module-name"
-}
-```

--- a/os/apps/chess/README.md
+++ b/os/apps/chess/README.md
@@ -1,17 +1,6 @@
 # chess
 
-Chess implementation for PrimeOS
-
-## Overview
-
-This module follows the standard PrimeOS module pattern, implementing the PrimeOS Model interface for consistent lifecycle management, state tracking, error handling, and integrated logging.
-
-## Features
-
-- Fully integrates with the PrimeOS model system
-- Built-in logging capabilities
-- Standard lifecycle management (initialize, process, reset, terminate)
-- Automatic error handling and result formatting
+Command line application that wires the chess engine into PrimeOS. It can run in interactive mode (human vs machine) or in automatic mode (machine vs machine) for a fixed depth.
 
 ## Installation
 
@@ -22,114 +11,31 @@ npm install chess
 ## Usage
 
 ```typescript
-import { createChess } from 'chess';
+import { createAndInitializeChess } from 'chess';
 
-// Create an instance
-const instance = createChess({
-  debug: true,
-  name: 'chess-instance',
-  version: '1.0.0'
-});
+const game = await createAndInitializeChess({ mode: 'human', depth: 3 });
+await game.play();
+```
 
-// Initialize the module
-await instance.initialize();
+### Command line examples
 
-// Process data
-const result = await instance.process('example-input');
-console.log(result);
+After building the project or running with `ts-node`, you can launch the game directly:
 
-// Clean up when done
-await instance.terminate();
+```bash
+# Human plays against the engine for three half moves
+npx ts-node os/apps/chess/index.ts --mode=human --depth=3
+
+# Engine plays against itself for ten half moves
+npx ts-node os/apps/chess/index.ts --mode=auto --depth=10
 ```
 
 ## API
 
-### `createChess(options)`
+- **`createChess(options?)`** – create a new game instance.
+- **`createAndInitializeChess(options?)`** – helper that initializes the instance.
+- **`play(): Promise<void>`** – start the CLI loop.
 
-Creates a new chess instance with the specified options.
+### Deterministic Behaviour
 
-Parameters:
-- `options` - Optional configuration options
+`chess` delegates all move generation to `chess-engine`. Because board states are encoded using deterministic prime mappings and the engine evaluates moves with the `EnhancedChunkVM`, the same command sequence will always yield the same result.
 
-Returns:
-- A chess instance implementing ChessInterface
-
-### ChessInterface
-
-The main interface implemented by chess. Extends the ModelInterface.
-
-Methods:
-- `initialize()` - Initialize the module (required before processing)
-- `process<T, R>(input: T)` - Process the input data and return a result
-- `reset()` - Reset the module to its initial state
-- `terminate()` - Release resources and shut down the module
-- `getState()` - Get the current module state
-- `getLogger()` - Get the module's logger instance
-
-### Options
-
-Configuration options for chess:
-
-```typescript
-interface ChessOptions {
-  // Enable debug mode
-  debug?: boolean;
-  
-  // Module name
-  name?: string;
-  
-  // Module version
-  version?: string;
-  
-  // Module-specific options
-  // ...
-}
-```
-
-### Result Format
-
-All operations return a standardized result format:
-
-```typescript
-{
-  success: true,          // Success indicator
-  data: { ... },          // Operation result data
-  timestamp: 1620000000,  // Operation timestamp
-  source: 'module-name'   // Source module
-}
-```
-
-## Lifecycle Management
-
-The module follows a defined lifecycle:
-
-1. **Uninitialized**: Initial state when created
-2. **Initializing**: During setup and resource allocation
-3. **Ready**: Available for processing
-4. **Processing**: Actively handling an operation
-5. **Error**: Encountered an issue
-6. **Terminating**: During resource cleanup
-7. **Terminated**: Final state after cleanup
-
-Always follow this sequence:
-1. Create the module with `createChess`
-2. Initialize with `initialize()`
-3. Process data with `process()`
-4. Clean up with `terminate()`
-
-## Custom Implementation
-
-You can extend the functionality by adding module-specific methods to the implementation.
-
-## Error Handling
-
-Errors are automatically caught and returned in a standardized format:
-
-```typescript
-{
-  success: false,
-  error: "Error message",
-  timestamp: 1620000000,
-  source: "module-name"
-}
-```


### PR DESCRIPTION
## Summary
- rewrite chess-core README with usage and deterministic prime mapping
- add prime-based and VM explanation for chess-engine
- document commands for human vs machine games in chess app

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845ba1d37d88320bb6df86fa7b76659