### PR TITLE
Expose chess modules and update CI

### DIFF
--- a/.github/workflows/precision-tests.yml
+++ b/.github/workflows/precision-tests.yml
@@ -5,11 +5,17 @@ on:
     branches: [ main, develop ]
     paths:
       - 'core/precision/**'
+      - 'core/chess-core/**'
+      - 'kernel/chess-engine/**'
+      - 'os/apps/chess/**'
       - '.github/workflows/precision-tests.yml'
   pull_request:
     branches: [ main, develop ]
     paths:
       - 'core/precision/**'
+      - 'core/chess-core/**'
+      - 'kernel/chess-engine/**'
+      - 'os/apps/chess/**'
       - '.github/workflows/precision-tests.yml'
 
 jobs:
@@ -121,6 +127,33 @@ jobs:
           } catch (error) {
             console.log('Could not read coverage report:', error.message);
           }
+
+    - name: Install chess module dependencies
+      run: |
+        cd core/chess-core && npm ci && cd -
+        cd kernel/chess-engine && npm ci && cd -
+        cd os/apps/chess && npm ci && cd -
+
+    - name: Run chess-core tests
+      run: |
+        cd core/chess-core
+        npm test
+      env:
+        CI: true
+
+    - name: Run chess-engine tests
+      run: |
+        cd kernel/chess-engine
+        npm test
+      env:
+        CI: true
+
+    - name: Run chess application tests
+      run: |
+        cd os/apps/chess
+        npm test
+      env:
+        CI: true
 
   individual-tests:
     runs-on: ubuntu-latest

--- a/core/index.ts
+++ b/core/index.ts
@@ -725,7 +725,7 @@ export async function createAndInitializeCore(options: CoreOptions = {}): Promis
 }
 
 // Re-export key module factory functions
-export { 
+export {
   createAndInitializePrecision,
   createAndInitializePrimeRegistry,
   createAndInitializeIntegrity,
@@ -733,6 +733,9 @@ export {
   createAndInitializeStream,
   createAndInitializeBands
 };
+
+// Export chess utilities
+export * from './chess-core';
 
 // Re-export precision APIs for direct use by modules and kernel
 export {

--- a/kernel/index.ts
+++ b/kernel/index.ts
@@ -1,0 +1,1 @@
+export * from './chess-engine';


### PR DESCRIPTION
## Summary
- export chess-core APIs from core index
- add kernel index exporting chess-engine
- run chess tests in CI

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845bb0ba4888320b533f184cf96f3de