### PR TITLE
Add tsconfig for Hanoi app

### DIFF
--- a/os/apps/hanoi/tsconfig.json
+++ b/os/apps/hanoi/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../core/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "../.."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
## Summary
- add TypeScript configuration for `os/apps/hanoi`

## Testing
- `npx tsc -p os/apps/hanoi --noEmit` *(fails: Cannot find name 'describe', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6845bea559b883209b3bd9b4e5697ece