### PR TITLE
Fix imports for chess modules

### DIFF
--- a/core/chess-core/index.ts
+++ b/core/chess-core/index.ts
@@ -11,7 +11,7 @@ import {
   ModelResult,
   ModelLifecycleState,
   createAndInitializeModel
-} from '../os/model';
+} from '../../os/model';
 import {
   ChessCoreOptions,
   ChessCoreInterface,

--- a/core/chess-core/test.ts
+++ b/core/chess-core/test.ts
@@ -11,7 +11,7 @@ import {
   ChessCoreOptions,
   ChessCoreState
 } from './index';
-import { ModelLifecycleState } from '../os/model';
+import { ModelLifecycleState } from '../../os/model';
 
 describe('chess-core', () => {
   let instance: ChessCoreInterface;

--- a/core/chess-core/types.ts
+++ b/core/chess-core/types.ts
@@ -11,8 +11,8 @@ import {
   ModelResult,
   ModelState,
   ModelLifecycleState
-} from '../os/model/types';
-import { LoggingInterface } from '../os/logging';
+} from '../../os/model/types';
+import { LoggingInterface } from '../../os/logging';
 
 /**
  * Configuration options for chess-core

--- a/kernel/chess-engine/index.ts
+++ b/kernel/chess-engine/index.ts
@@ -6,7 +6,7 @@
  * It follows the standard PrimeOS model pattern.
  */
 
-import { BaseModel } from '../os/model';
+import { BaseModel } from '../../os/model';
 import {
   ChessEngineOptions,
   ChessEngineInterface,

--- a/kernel/chess-engine/test.ts
+++ b/kernel/chess-engine/test.ts
@@ -9,7 +9,7 @@ import {
   createChessEngine,
   ChessEngineInterface
 } from './index';
-import { ModelLifecycleState } from '../os/model';
+import { ModelLifecycleState } from '../../os/model';
 import { fenToBoardState } from '../core/chess-core/board';
 
 describe('chess-engine', () => {

--- a/kernel/chess-engine/types.ts
+++ b/kernel/chess-engine/types.ts
@@ -10,8 +10,8 @@ import {
   ModelInterface,
   ModelResult,
   ModelState
-} from '../os/model/types';
-import { LoggingInterface } from '../os/logging';
+} from '../../os/model/types';
+import { LoggingInterface } from '../../os/logging';
 import { BoardState, ChessMove } from '../core/chess-core/types';
 
 /**

--- a/os/apps/chess/index.ts
+++ b/os/apps/chess/index.ts
@@ -8,7 +8,7 @@
 
 import {
   BaseModel
-} from '../os/model';
+} from '../../model';
 import {
   ChessOptions,
   ChessInterface,

--- a/os/apps/chess/test.ts
+++ b/os/apps/chess/test.ts
@@ -11,7 +11,7 @@ import {
   ChessOptions,
   ChessState
 } from './index';
-import { ModelLifecycleState } from '../os/model';
+import { ModelLifecycleState } from '../../model';
 
 describe('chess', () => {
   let instance: ChessInterface;

--- a/os/apps/chess/types.ts
+++ b/os/apps/chess/types.ts
@@ -11,8 +11,8 @@ import {
   ModelResult,
   ModelState,
   ModelLifecycleState
-} from '../os/model/types';
-import { LoggingInterface } from '../os/logging';
+} from '../../model/types';
+import { LoggingInterface } from '../../logging';
 
 /**
  * Configuration options for chess


### PR DESCRIPTION
## Summary
- adjust relative imports in `chess-core`
- adjust relative imports in `chess-engine`
- adjust relative imports in `os/apps/chess`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6845c053cf0083208877571c4b2a8590