### PR TITLE
Document test prereqs

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -67,6 +67,12 @@ module-name/
 
 ## Testing
 
+First, install dependencies to ensure Jest and related typings are available:
+
+```bash
+npm install
+```
+
 Run tests for all modules:
 
 ```bash

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 # Testing PrimeOS
 
-PrimeOS uses Jest for unit tests and includes additional test runners. Before running the test suite, install dependencies:
+PrimeOS uses Jest for unit tests and includes additional test runners. Jest and its TypeScript typings are included in the dev dependencies of the root `package.json`. Before running the test suite, install dependencies:
 
 ```bash
 npm install


### PR DESCRIPTION
## Summary
- clarify how to install dependencies before running Jest tests
- mention that Jest and typings are included in the main package

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845c2e9105c8320933786034da266f6