### PR TITLE
Add chess web interface module

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The `os` package provides high-level system capabilities:
 Application modules live under the `os/apps` directory. They serve as examples of how to build on the PrimeOS runtime and leverage the model system. A small but growing set of apps is included:
 
 - **Tower of Hanoi** – a puzzle solver demonstrating recursive processing and lifecycle management.
+- **Chess Web** – a lightweight web interface for playing against the built-in chess engine.
 
 ## Design Philosophy
 

--- a/os/apps/chess-web/README.md
+++ b/os/apps/chess-web/README.md
@@ -1,0 +1,20 @@
+# chess-web
+
+A minimal web interface around the PrimeOS chess engine.
+
+## Overview
+
+This module exposes a small HTTP service using Express. It wraps the existing
+`chess` application and provides a REST API along with static assets so the game
+can be played in the browser.
+
+## Setup
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+The server listens on port `3000` by default. Open
+`http://localhost:3000` in your browser to play.

--- a/os/apps/chess-web/index.ts
+++ b/os/apps/chess-web/index.ts
@@ -1,0 +1,50 @@
+import express, { Application } from 'express';
+import path from 'path';
+import { createAndInitializeChess } from '../chess';
+import { ChessEngineInterface } from '../../kernel/chess-engine';
+
+let engine: ChessEngineInterface;
+
+export async function createServer(): Promise<Application> {
+  const chess: any = await createAndInitializeChess();
+  engine = chess.engine as ChessEngineInterface;
+
+  const app = express();
+  app.use(express.json());
+
+  app.use(express.static(path.resolve(__dirname, '../public')));
+
+  app.post('/api/new-game', async (_req, res) => {
+    await chess.reset();
+    res.json({ board: engine.getState().custom?.board });
+  });
+
+  app.post('/api/player-move', async (req, res) => {
+    const { from, to } = req.body;
+    if (!from || !to) {
+      res.status(400).json({ error: 'from and to required' });
+      return;
+    }
+    await engine.applyMove({ from, to });
+    const engineMove = await engine.computeMove();
+    if (engineMove) {
+      await engine.applyMove(engineMove);
+    }
+    res.json({ engineMove, board: engine.getState().custom?.board });
+  });
+
+  app.get('/api/board', (_req, res) => {
+    res.json({ board: engine.getState().custom?.board });
+  });
+
+  return app;
+}
+
+if (require.main === module) {
+  const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+  createServer().then(app => {
+    app.listen(PORT, () => {
+      console.log(`Chess web server running on http://localhost:${PORT}`);
+    });
+  });
+}

--- a/os/apps/chess-web/package.json
+++ b/os/apps/chess-web/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "chess-web",
+  "version": "0.1.0",
+  "description": "Web interface for the chess engine",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "keywords": [
+    "primeos",
+    "chess-web"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2",
+    "chess": "^0.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/jest": "^29.5.3",
+    "@types/supertest": "^2.0.12",
+    "jest": "^29.6.2",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.1.6"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
+  }
+}

--- a/os/apps/chess-web/public/app.js
+++ b/os/apps/chess-web/public/app.js
@@ -1,0 +1,45 @@
+async function fetchBoard() {
+  const res = await fetch('/api/board');
+  const data = await res.json();
+  renderBoard(data.board);
+}
+
+function renderBoard(fen) {
+  const boardDiv = document.getElementById('board');
+  const table = document.createElement('table');
+  const rows = fen.split(' ')[0].split('/');
+  rows.forEach(row => {
+    const tr = document.createElement('tr');
+    for (const ch of row) {
+      if (isNaN(parseInt(ch))) {
+        const td = document.createElement('td');
+        td.textContent = ch;
+        tr.appendChild(td);
+      } else {
+        for (let i = 0; i < parseInt(ch); i++) {
+          const td = document.createElement('td');
+          tr.appendChild(td);
+        }
+      }
+    }
+    table.appendChild(tr);
+  });
+  boardDiv.innerHTML = '';
+  boardDiv.appendChild(table);
+}
+
+document.getElementById('moveForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const from = document.getElementById('from').value;
+  const to = document.getElementById('to').value;
+  const res = await fetch('/api/player-move', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ from, to })
+  });
+  const data = await res.json();
+  if (data.board) renderBoard(data.board);
+  document.getElementById('status').textContent = data.engineMove ? `Engine move: ${data.engineMove.from}${data.engineMove.to}` : '';
+});
+
+fetchBoard();

--- a/os/apps/chess-web/public/index.html
+++ b/os/apps/chess-web/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Chess Web</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Chess Web</h1>
+  <div id="board"></div>
+  <div id="status"></div>
+  <form id="moveForm">
+    <input id="from" placeholder="from" maxlength="2">
+    <input id="to" placeholder="to" maxlength="2">
+    <button type="submit">Move</button>
+  </form>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/os/apps/chess-web/public/style.css
+++ b/os/apps/chess-web/public/style.css
@@ -1,0 +1,3 @@
+body { font-family: sans-serif; }
+#board table { border-collapse: collapse; }
+#board td { width: 40px; height: 40px; text-align: center; border: 1px solid #999; }

--- a/os/apps/chess-web/test.ts
+++ b/os/apps/chess-web/test.ts
@@ -1,0 +1,27 @@
+import request from 'supertest';
+import { createServer } from './index';
+
+describe('chess-web endpoints', () => {
+  let app: any;
+  beforeAll(async () => {
+    app = await createServer();
+  });
+
+  test('GET /api/board', async () => {
+    const res = await request(app).get('/api/board');
+    expect(res.status).toBe(200);
+    expect(res.body.board).toBeDefined();
+  });
+
+  test('POST /api/new-game', async () => {
+    const res = await request(app).post('/api/new-game');
+    expect(res.status).toBe(200);
+    expect(res.body.board).toBeDefined();
+  });
+
+  test('POST /api/player-move', async () => {
+    const res = await request(app).post('/api/player-move').send({ from: 'e2', to: 'e4' });
+    expect(res.status).toBe(200);
+    expect(res.body.board).toBeDefined();
+  });
+});

--- a/os/apps/chess-web/tsconfig.json
+++ b/os/apps/chess-web/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../core/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "../.."
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/os/apps/chess-web/types.ts
+++ b/os/apps/chess-web/types.ts
@@ -1,0 +1,26 @@
+/**
+ * chess-web Types
+ * ---------------
+ * Type definitions for the chess-web module.
+ */
+
+import { ModelOptions, ModelInterface, ModelResult, ModelState } from '../../model/types';
+import { LoggingInterface } from '../../logging';
+
+export interface ChessWebOptions extends ModelOptions {
+  /** Port to listen on */
+  port?: number;
+}
+
+export interface ChessWebInterface extends ModelInterface {
+  /** Start the HTTP server */
+  start(): Promise<void>;
+  getLogger(): LoggingInterface;
+}
+
+export type ChessWebResult<T = unknown> = ModelResult<T>;
+
+export interface ChessWebState extends ModelState {
+  /** Current port */
+  port?: number;
+}

--- a/os/apps/index.ts
+++ b/os/apps/index.ts
@@ -8,4 +8,5 @@
 
 export * from './hanoi';
 export * from './chess';
+export * from './chess-web';
 


### PR DESCRIPTION
## Summary
- add new `chess-web` application module
- serve a small Express web server exposing chess API routes
- include minimal browser front‑end
- document how to build and run the server
- export the module and mention it in the root README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845c8854dd48320881668ae5191e5f6