### PR TITLE
Implement skeleton VM move generation

### DIFF
--- a/core/encoding/vm/vm-enhanced.ts
+++ b/core/encoding/vm/vm-enhanced.ts
@@ -393,14 +393,29 @@ export class EnhancedChunkVM {
       case ExtendedOpcodes.OP_LOAD:
         if (operand !== undefined) {
           this.stack.push(this.memory[operand] || 0);
+        } else {
+          if (this.stack.length < 1) {
+            throw new VMExecutionError('LOAD', 'LOAD requires address on stack');
+          }
+          const addr = this.stack.pop()!;
+          this.stack.push(this.memory[addr] || 0);
         }
         break;
-        
+
       case ExtendedOpcodes.OP_STORE:
-        if (this.stack.length < 1 || operand === undefined) {
-          throw new VMExecutionError('STORE', 'STORE requires stack value and memory address');
+        if (operand !== undefined) {
+          if (this.stack.length < 1) {
+            throw new VMExecutionError('STORE', 'STORE requires stack value');
+          }
+          this.memory[operand] = this.stack.pop()!;
+        } else {
+          if (this.stack.length < 2) {
+            throw new VMExecutionError('STORE', 'STORE requires value and address on stack');
+          }
+          const addr = this.stack.pop()!;
+          const val = this.stack.pop()!;
+          this.memory[addr] = val;
         }
-        this.memory[operand] = this.stack.pop()!;
         break;
         
       // I/O operations

--- a/kernel/chess-engine/test.ts
+++ b/kernel/chess-engine/test.ts
@@ -69,6 +69,14 @@ describe('chess-engine', () => {
       const m2 = await instance.computeMove();
       expect(m1).toEqual(m2);
     });
+
+    test('move list generation via VM', async () => {
+      const start = fenToBoardState('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1');
+      await instance.loadPosition(start);
+      const moves = (instance as any).generateMoves(start);
+      expect(Array.isArray(moves)).toBe(true);
+      expect(moves.length).toBeGreaterThan(0);
+    });
   });
 
   describe('Training', () => {

--- a/kernel/chess-engine/vm-moves.ts
+++ b/kernel/chess-engine/vm-moves.ts
@@ -1,0 +1,58 @@
+import { BoardState, ChessMove, ChessPiece, Square } from '../core/chess-core/types';
+import { ChunkType } from '../core/encoding/core/types';
+import { ExtendedOpcodes, StandardOpcodes } from '../core/encoding/vm/vm-enhanced';
+
+/**
+ * Helper to convert board pieces to numeric codes for the VM.
+ */
+function pieceCode(p?: ChessPiece): number {
+  if (!p) return 0;
+  const table: Record<ChessPiece, number> = {
+    [ChessPiece.WhitePawn]: 1,
+    [ChessPiece.WhiteKnight]: 2,
+    [ChessPiece.WhiteBishop]: 3,
+    [ChessPiece.WhiteRook]: 4,
+    [ChessPiece.WhiteQueen]: 5,
+    [ChessPiece.WhiteKing]: 6,
+    [ChessPiece.BlackPawn]: 7,
+    [ChessPiece.BlackKnight]: 8,
+    [ChessPiece.BlackBishop]: 9,
+    [ChessPiece.BlackRook]: 10,
+    [ChessPiece.BlackQueen]: 11,
+    [ChessPiece.BlackKing]: 12,
+  };
+  return table[p];
+}
+
+export function createMoveGenerationProgram(board: BoardState) {
+  const program: any[] = [];
+  // initialize board memory
+  const files = ['a','b','c','d','e','f','g','h'] as const;
+  const ranks = [1,2,3,4,5,6,7,8] as const;
+  let idx = 0;
+  for (const r of ranks) {
+    for (const f of files) {
+      const sq = `${f}${r}` as Square;
+      program.push({ type: ChunkType.OPERATION, checksum: 0n, data: { opcode: StandardOpcodes.OP_PUSH, operand: pieceCode(board.pieces[sq]) } });
+      program.push({ type: ChunkType.OPERATION, checksum: 0n, data: { opcode: ExtendedOpcodes.OP_STORE, operand: idx } });
+      idx++;
+    }
+  }
+
+  // TODO: actual move generation logic using loops and memory access
+  // For now just halt
+  program.push({ type: ChunkType.OPERATION, checksum: 0n, data: { opcode: ExtendedOpcodes.OP_HALT } });
+  return program;
+}
+
+export function decodeMoveOutput(out: string[]): ChessMove[] {
+  const moves: ChessMove[] = [];
+  const text = out.join('');
+  for (const token of text.trim().split(/\s+/)) {
+    if (token.length < 4) continue;
+    const from = token.slice(0,2) as Square;
+    const to = token.slice(2,4) as Square;
+    moves.push({ from, to });
+  }
+  return moves;
+}


### PR DESCRIPTION
## Summary
- extend EnhancedChunkVM with dynamic load/store operations
- prototype VM-based move generator and decoding helpers
- integrate VM move generation in chess engine
- add test exercising VM move list

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68460495f72083208d50be2bdc223bc0