### PR TITLE
Add minimax search to chess engine

### DIFF
--- a/kernel/chess-engine/index.ts
+++ b/kernel/chess-engine/index.ts
@@ -369,6 +369,72 @@ export class ChessEngineImplementation extends BaseModel implements ChessEngineI
     return best;
   }
 
+  async search(depth: number): Promise<ChessMove | null> {
+    const maximizing = this.board.activeColor === 'w';
+
+    const minimax = (board: BoardState, d: number, alpha: number, beta: number, max: boolean): { move: ChessMove | null; val: number } => {
+      const moves = this.generateMoves(board);
+      if (d === 0 || moves.length === 0) {
+        if (moves.length === 0) {
+          const inCheck = this.isKingInCheck(board, board.activeColor);
+          if (inCheck) return { move: null, val: max ? -Infinity : Infinity };
+          return { move: null, val: 0 };
+        }
+        const prog = this.evaluationProgram(board);
+        const out = this.vm.execute(prog as any);
+        const val = parseInt(out[out.length - 1] || '0', 10);
+        return { move: null, val };
+      }
+
+      let bestMove: ChessMove | null = null;
+      if (max) {
+        let bestVal = -Infinity;
+        for (const m of moves) {
+          const next = JSON.parse(JSON.stringify(board)) as BoardState;
+          this.applyMoveTo(next, m);
+          next.activeColor = board.activeColor === 'w' ? 'b' : 'w';
+          if (m.promotion || next.pieces[m.to]?.toLowerCase() === 'p' || next.enPassant !== null) {
+            next.halfmove = 0;
+          } else {
+            next.halfmove += 1;
+          }
+          if (next.activeColor === 'w') next.fullmove += 1;
+          const res = minimax(next, d - 1, alpha, beta, false);
+          if (res.val > bestVal) {
+            bestVal = res.val;
+            bestMove = m;
+          }
+          alpha = Math.max(alpha, res.val);
+          if (beta <= alpha) break;
+        }
+        return { move: bestMove, val: bestVal };
+      } else {
+        let bestVal = Infinity;
+        for (const m of moves) {
+          const next = JSON.parse(JSON.stringify(board)) as BoardState;
+          this.applyMoveTo(next, m);
+          next.activeColor = board.activeColor === 'w' ? 'b' : 'w';
+          if (m.promotion || next.pieces[m.to]?.toLowerCase() === 'p' || next.enPassant !== null) {
+            next.halfmove = 0;
+          } else {
+            next.halfmove += 1;
+          }
+          if (next.activeColor === 'w') next.fullmove += 1;
+          const res = minimax(next, d - 1, alpha, beta, true);
+          if (res.val < bestVal) {
+            bestVal = res.val;
+            bestMove = m;
+          }
+          beta = Math.min(beta, res.val);
+          if (beta <= alpha) break;
+        }
+        return { move: bestMove, val: bestVal };
+      }
+    };
+
+    return minimax(this.board, depth, -Infinity, Infinity, maximizing).move;
+  }
+
   private applyMoveTo(board: BoardState, move: ChessMove) {
     const piece = board.pieces[move.from];
     if (!piece) return;

--- a/kernel/chess-engine/test.ts
+++ b/kernel/chess-engine/test.ts
@@ -77,6 +77,22 @@ describe('chess-engine', () => {
       expect(Array.isArray(moves)).toBe(true);
       expect(moves.length).toBeGreaterThan(0);
     });
+
+    test('search depth 1 matches computeMove', async () => {
+      const start = fenToBoardState('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1');
+      await instance.loadPosition(start);
+      const s = await (instance as any).search(1);
+      const c = await instance.computeMove();
+      expect(s).toEqual(c);
+    });
+
+    test('search depth 2 deterministic', async () => {
+      const start = fenToBoardState('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1');
+      await instance.loadPosition(start);
+      const a = await (instance as any).search(2);
+      const b = await (instance as any).search(2);
+      expect(a).toEqual(b);
+    });
   });
 
   describe('Piece move generation', () => {

--- a/kernel/chess-engine/types.ts
+++ b/kernel/chess-engine/types.ts
@@ -34,6 +34,9 @@ export interface ChessEngineInterface extends ModelInterface {
   /** Compute best move from current position */
   computeMove(): Promise<ChessMove | null>;
 
+  /** Search best move to given depth using minimax */
+  search(depth: number): Promise<ChessMove | null>;
+
   /** Apply a move to the current board */
   applyMove(move: ChessMove): Promise<void>;
 

--- a/os/apps/chess-web/index.ts
+++ b/os/apps/chess-web/index.ts
@@ -27,18 +27,14 @@ export async function createServer(): Promise<Application> {
       return;
     }
     await engine.applyMove({ from, to, promotion });
-    let engineMove = await (engine as any).search
-      ? await (engine as any).search(1)
-      : await engine.computeMove();
+    let engineMove = await (engine as any).search(1);
     let gameOver = false;
     let check = false;
     if (engineMove) {
       await engine.applyMove(engineMove);
       const state = fenToBoardState(engine.getState().custom?.board as string);
       check = (engine as any).isKingInCheck?.(state, state.activeColor);
-      const next = await ((engine as any).search
-        ? (engine as any).search(1)
-        : engine.computeMove());
+      const next = await (engine as any).search(1);
       if (!next) gameOver = true;
     } else {
       const state = fenToBoardState(engine.getState().custom?.board as string);

--- a/os/apps/chess/index.ts
+++ b/os/apps/chess/index.ts
@@ -112,11 +112,7 @@ export class ChessImplementation extends BaseModel implements ChessInterface {
     }
     if (mode === 'auto') {
       for (let i = 0; i < depth; i++) {
-        const mv = typeof (this.engine as any).search === 'function'
-          ? await (this.engine as any).search(searchDepth)
-          : (this.engine as any).computeMove.length
-            ? await (this.engine as any).computeMove(searchDepth)
-            : await this.engine.computeMove();
+        const mv = await (this.engine as any).search(searchDepth);
         if (!mv) {
           const board = this.engine.getState().custom?.board as string;
           const state = fenToBoardState(board);
@@ -136,11 +132,7 @@ export class ChessImplementation extends BaseModel implements ChessInterface {
         const from = answer.slice(0, 2) as Square;
         const to = answer.slice(2, 4) as Square;
         await this.engine.applyMove({ from, to });
-        let mv = typeof (this.engine as any).search === 'function'
-          ? await (this.engine as any).search(searchDepth)
-          : (this.engine as any).computeMove.length
-            ? await (this.engine as any).computeMove(searchDepth)
-            : await this.engine.computeMove();
+        let mv = await (this.engine as any).search(searchDepth);
         if (!mv) {
           const board = this.engine.getState().custom?.board as string;
           const state = fenToBoardState(board);


### PR DESCRIPTION
## Summary
- implement recursive minimax search with alpha-beta pruning in the chess engine
- expose new `search(depth)` API on the engine
- use `search` from CLI and web apps
- test that search is deterministic and matches `computeMove` at depth 1

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846a62d164483209d5ddf51facfcba0