### PR TITLE
Add search fallback usage

### DIFF
--- a/kernel/chess-engine/test.ts
+++ b/kernel/chess-engine/test.ts
@@ -93,6 +93,14 @@ describe('chess-engine', () => {
       const b = await (instance as any).search(2);
       expect(a).toEqual(b);
     });
+
+    test('search depth 3 deterministic', async () => {
+      const start = fenToBoardState('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1');
+      await instance.loadPosition(start);
+      const a = await (instance as any).search(3);
+      const b = await (instance as any).search(3);
+      expect(a).toEqual(b);
+    });
   });
 
   describe('Piece move generation', () => {

--- a/os/apps/chess-web/index.ts
+++ b/os/apps/chess-web/index.ts
@@ -27,14 +27,19 @@ export async function createServer(): Promise<Application> {
       return;
     }
     await engine.applyMove({ from, to, promotion });
-    let engineMove = await (engine as any).search(1);
+    const hasSearch = typeof (engine as any).search === 'function';
+    let engineMove = hasSearch
+      ? await (engine as any).search(1)
+      : await engine.computeMove();
     let gameOver = false;
     let check = false;
     if (engineMove) {
       await engine.applyMove(engineMove);
       const state = fenToBoardState(engine.getState().custom?.board as string);
       check = (engine as any).isKingInCheck?.(state, state.activeColor);
-      const next = await (engine as any).search(1);
+      const next = hasSearch
+        ? await (engine as any).search(1)
+        : await engine.computeMove();
       if (!next) gameOver = true;
     } else {
       const state = fenToBoardState(engine.getState().custom?.board as string);

--- a/os/apps/chess/index.ts
+++ b/os/apps/chess/index.ts
@@ -110,9 +110,12 @@ export class ChessImplementation extends BaseModel implements ChessInterface {
     if (!this.engine) {
       throw new Error('Engine not initialized');
     }
+    const hasSearch = typeof (this.engine as any).search === 'function';
     if (mode === 'auto') {
       for (let i = 0; i < depth; i++) {
-        const mv = await (this.engine as any).search(searchDepth);
+        const mv = hasSearch
+          ? await (this.engine as any).search(searchDepth)
+          : await this.engine.computeMove();
         if (!mv) {
           const board = this.engine.getState().custom?.board as string;
           const state = fenToBoardState(board);
@@ -132,7 +135,9 @@ export class ChessImplementation extends BaseModel implements ChessInterface {
         const from = answer.slice(0, 2) as Square;
         const to = answer.slice(2, 4) as Square;
         await this.engine.applyMove({ from, to });
-        let mv = await (this.engine as any).search(searchDepth);
+        let mv = hasSearch
+          ? await (this.engine as any).search(searchDepth)
+          : await this.engine.computeMove();
         if (!mv) {
           const board = this.engine.getState().custom?.board as string;
           const state = fenToBoardState(board);


### PR DESCRIPTION
## Summary
- use `search` when available in the CLI
- check for `search` in the web server
- ensure `search` is deterministic at depth 3

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846d6c2d19c832090656fec2deaaac4